### PR TITLE
Update chromedriver to 2.16

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -9,7 +9,7 @@ import { parallel as ll } from 'asyncbox';
 import { exists } from './utils';
 const { system, tempDir } = support;
 
-const CD_VER = "2.15";
+const CD_VER = "2.16";
 const CD_CDN = "http://chromedriver.storage.googleapis.com";
 const CD_BASE_DIR = path.resolve(__dirname, "..", "..", "chromedriver");
 const CD_PLATS = ["linux", "win", "mac"];


### PR DESCRIPTION
From official changelog: https://chromedriver.storage.googleapis.com/2.16/notes.txt
```
----------ChromeDriver v2.16 (2015-06-08)----------
Supports Chrome v42-45
```

And a bit more from commit history: https://github.com/bayandin/chromedriver/compare/2.15...2.16