### PR TITLE
Add hashbang to install script so it can be run on its own

### DIFF
--- a/install-npm.js
+++ b/install-npm.js
@@ -1,13 +1,14 @@
+#!/usr/bin/env node
+
 var fs = require('fs')
   , path = require('path');
 
 if (require.main === module) {
   // check if cur dir exists
-  var installScript = path.resolve(__dirname, "build", "lib",
-     "install.js");
+  var installScript = path.resolve(__dirname, 'build', 'lib', 'install.js');
   fs.stat(installScript, function (err) {
     if (err) {
-      console.warn("NOTE: Run 'npm run-script chromedriver' before using");
+      console.warn("NOTE: Run 'gulp transpile' before using");
       return;
     }
     require('./build/lib/install').doInstall().catch(function (err) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -5,6 +5,8 @@ import request from 'request-promise';
 import AdmZip from 'adm-zip';
 import { parallel as ll } from 'asyncbox';
 import { system, tempDir, fs } from 'appium-support';
+
+
 const log = getLogger('Chromedriver Install');
 
 const CD_VER = process.env.npm_config_chromedriver_version || "2.18";


### PR DESCRIPTION
People sometimes try to run `./install-npm.js`.