### PR TITLE
Add retry logic to install script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import {default as chromedriver} from './lib/chromedriver';
+import { default as chromedriver } from './lib/chromedriver';
 
 export default chromedriver;

--- a/install-npm.js
+++ b/install-npm.js
@@ -3,17 +3,45 @@
 var fs = require('fs')
   , path = require('path');
 
+
+function waitForDeps (cb) {
+  // see if we can import the necessary code
+  // try it a ridiculous (but finite) number of times
+  var i = 0;
+  function check () {
+    i++;
+    try {
+      require('./build/lib/install');
+      cb();
+    } catch (err) {
+      console.warn('Error trying to install Chromedriver binary. Waiting and trying again.');
+      if (i <= 200) {
+        setTimeout(check, 1000);
+      } else {
+        cb('Could not import install module: ' + err);
+      }
+    }
+  }
+  check();
+}
+
 if (require.main === module) {
   // check if cur dir exists
   var installScript = path.resolve(__dirname, 'build', 'lib', 'install.js');
-  fs.stat(installScript, function (err) {
+  waitForDeps(function (err) {
     if (err) {
-      console.warn("NOTE: Run 'gulp transpile' before using");
+      console.warn("Unable to import install script. Re-run `install appium-chromedriver` manually.");
       return;
     }
-    require('./build/lib/install').doInstall().catch(function (err) {
-      console.error(err.stack ? err.stack : err);
-      process.exit(1);
+    fs.stat(installScript, function (err) {
+      if (err) {
+        console.warn("NOTE: Run 'gulp transpile' before using");
+        return;
+      }
+      require('./build/lib/install').doInstall().catch(function (err) {
+        console.error(err.stack ? err.stack : err);
+        process.exit(1);
+      });
     });
   });
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -151,4 +151,4 @@ async function doInstall () {
 }
 
 export { getChromedriverBinaryPath, install, installAll, CD_BASE_DIR,
-         getCurPlatform, conditionalInstall, doInstall};
+         getCurPlatform, conditionalInstall, doInstall };


### PR DESCRIPTION
When installing from a parent module, the install script tries to run before all the required dependencies are installed. This most often manifests as not being able to find `babel-runtime` files. To alleviate this, try to import the real install file, and keep doing it until it works.