### PR TITLE
Do install script after prepublish

### DIFF
--- a/install-npm.js
+++ b/install-npm.js
@@ -14,11 +14,15 @@ function waitForDeps (cb) {
       require('./build/lib/install');
       cb();
     } catch (err) {
-      console.warn('Error trying to install Chromedriver binary. Waiting and trying again.');
+      if (err.message.indexOf("Cannot find module './build/lib/install'") !== -1) {
+        console.warn('Project does not appear to built yet. Please run `gulp transpile` first.');
+        return cb('Could not install module: ' + err);
+      }
+      console.warn('Error trying to install Chromedriver binary. Waiting and trying again.', err.message);
       if (i <= 200) {
         setTimeout(check, 1000);
       } else {
-        cb('Could not import install module: ' + err);
+        cb('Could not install module: ' + err);
       }
     }
   }
@@ -31,7 +35,7 @@ if (require.main === module) {
   waitForDeps(function (err) {
     if (err) {
       console.warn("Unable to import install script. Re-run `install appium-chromedriver` manually.");
-      return;
+      process.exit(1);
     }
     fs.stat(installScript, function (err) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -43,15 +43,14 @@
     "through": "^2.3.7"
   },
   "scripts": {
-    "prepublish": "gulp prepublish",
+    "prepublish": "gulp prepublish && node install-npm.js",
     "test": "gulp once",
     "watch": "gulp",
-    "install": "node install-npm.js",
     "chromedriver": "node install-npm.js",
     "chromedriver_all": "node install-npm.js --all"
   },
   "devDependencies": {
-    "appium-gulp-plugins": "^1.3.12",
+    "appium-gulp-plugins": "^1.4.0",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
If the transpile process hadn't happened, we would get into a long loop trying to install the binary, which could never happen.