### PR TITLE
Use pkill instead of xargs + kill

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -211,9 +211,7 @@ class Chromedriver extends events.EventEmitter {
             "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
             "/F /PID %a))";
     } else {
-      cmd = `ps -ef | grep ${this.chromedriver} | grep -v grep |` +
-            `grep -e '--port=${this.proxyPort}\\(\\s.*\\)\\?$' | awk ` +
-            `'{ print $2 }' | xargs kill -15`;
+      cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
     }
     log.info(`Killing any old chromedrivers, running: ${cmd}`);
     try {


### PR DESCRIPTION
Fixes a bug which causes killing of all user's processes in Ubuntu 16.04 if no previous chromedriver instances are present. This behaviour is described [here][1] and [here][2].

Tests were run and pass under Ubuntu 16.04 and OS X El Capitan 10.11.4.

[1]: http://ubuntuforums.org/showthread.php?t=2322677
[2]: https://bugs.launchpad.net/ubuntu/+source/procps/+bug/1577297