### PR TITLE
Upgrading chromedriver to 2.23 and ensuring that the 64-bit version is downloaded for mac

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -9,7 +9,7 @@ import { system, tempDir, fs } from 'appium-support';
 
 const log = getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || "2.21";
+const CD_VER = process.env.npm_config_chromedriver_version || "2.23";
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                "http://chromedriver.storage.googleapis.com";
@@ -56,8 +56,8 @@ function validatePlatform (platform, arch) {
   if (!_.contains(CD_ARCHS, arch)) {
     throw new Error(`Invalid arch: ${arch}`);
   }
-  if (arch === "64" && platform !== "linux") {
-    throw new Error("Only linux has a 64-bit version of Chromedriver");
+  if (arch === "64" && platform !== "linux" && platform !== "mac") {
+    throw new Error("Only linux and mac have a 64-bit version of Chromedriver");
   }
 }
 
@@ -109,7 +109,7 @@ async function installForPlatform (version, platform, arch) {
 
 async function install () {
   let arch = await system.arch(), platform = getCurPlatform();
-  if (platform !== "linux" && arch === "64") {
+  if (platform !== "linux" && platform !== "mac" && arch === "64") {
     arch = "32";
   }
   await installForPlatform(CD_VER, platform, arch);
@@ -117,7 +117,7 @@ async function install () {
 
 async function conditionalInstall () {
   let arch = await system.arch(), platform = getCurPlatform();
-  if (platform !== "linux" && arch === "64") {
+  if (platform !== "linux" && platform !== "mac" && arch === "64") {
     arch = "32";
   }
   let binPath = await getChromedriverBinaryPath(platform, arch);
@@ -133,7 +133,7 @@ async function installAll () {
     ['linux', '32'],
     ['linux', '64'],
     ['win', '32'],
-    ['mac', '32']
+    ['mac', '64']
   ];
   let downloads = [];
   for (let [platform, arch] of plats) {

--- a/test/install-specs.js
+++ b/test/install-specs.js
@@ -32,7 +32,7 @@ describe('install scripts', function () {
     await install();
     let cdPath = await getChromedriverBinaryPath();
     let cdStat = await fs.stat(cdPath);
-    cdStat.size.should.be.above(5000000);
+    cdStat.size.should.be.above(500000);
     cdPath.should.contain(getCurPlatform());
     let cd = new Chromedriver();
     await cd.initChromedriverPath();
@@ -46,12 +46,12 @@ describe('install scripts', function () {
       ['linux', '32'],
       ['linux', '64'],
       ['win', '32'],
-      ['mac', '32']
+      ['mac', '64']
     ];
     for (let [platform, arch] of plats) {
       let cdPath = await getChromedriverBinaryPath(platform, arch);
       let cdStat = await fs.stat(cdPath);
-      cdStat.size.should.be.above(5000000);
+      cdStat.size.should.be.above(500000);
       cdPath.should.contain(platform);
       if (platform === "linux") {
         cdPath.should.contain(arch);


### PR DESCRIPTION
Apparently starting from version 2.23, chromedriver has switched from compiling a single 32-bit version for mac to a single 64-bit version, which makes sense because 32-bit macs have not existed in years.

Not all tests passed even before any of my changes, so I'm not entirely sure if more changes are necessary on my end.

Fix for https://github.com/appium/appium/issues/6634.