### PR TITLE
Clean adb forward resource when kill chromedriver process

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -216,7 +216,7 @@ class Chromedriver extends events.EventEmitter {
 
   async killAll () {
     let cmd;
-    let cmd_adb;
+    let cmdAdb;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
       cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +
@@ -224,23 +224,26 @@ class Chromedriver extends events.EventEmitter {
             "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
             "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
             "/F /PID %a))";
-      cmd_adb = "FOR /F \"usebackq tokens=2\" %a in (`adb forward --list ^| findstr /R /C:\"webview\"`) do ( adb forward --remove %a )";
+      cmdAdb = "FOR /F \"usebackq tokens=2\" %a in (`adb forward --list ^| findstr /R /C:\"webview\"`) do ( adb forward --remove %a )";
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
-      cmd_adb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
+      cmdAdb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
     }
     log.info(`Killing any old chromedrivers, running: ${cmd}`);
+    const cp_exec = B.promisify(cp.exec);
+    log.debug(`Killing any old chromedrivers, running: ${cmd}`);
     try {
-      await (B.promisify(cp.exec))(cmd);
-      log.info("Successfully cleaned up old chromedrivers");
+      await cp_exec(cmd);
+      log.debug("Successfully cleaned up old chromedrivers");
     } catch (err) {
-      log.info("No old chromedrivers seemed to exist");
+      log.warn("No old chromedrivers seemed to exist");
     }
+    log.debug(`Cleaning any old chromedriver port forwarding resources, running: ${cmd_adb}`);
     try {
-      await (B.promisify(cp.exec))(cmd_adb);
-      log.info("Successfully cleaned up adb forward resource");
+      await cp_exec(cmd_adb);
+      log.debug("Successfully cleaned up adb forward resource");
     } catch (err) {
-      log.info("No adb forward resource seemed to exist");
+      log.warn("No adb forward resource seemed to exist");
     }
   }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -216,7 +216,6 @@ class Chromedriver extends events.EventEmitter {
 
   async killAll () {
     let cmd;
-    let adb = this.adb;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
       cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +
@@ -235,16 +234,14 @@ class Chromedriver extends events.EventEmitter {
       log.warn("No old chromedrivers seemed to exist");
     }
     log.debug(`Clean any old adb forwarded port socket connections`);
-    let forwardList = await adb.forwardList();
-    if(forwardList){
-        forwardList.split("\n").map(function (forwardLine){
-            if(forwardLine.indexOf("webview_devtools") >= 0){
-                forwardParams = forwardLine.split(/\s+/);
-                if(forwardParams.length >= 2){
-                    adb.removePortForward(forwardParams[1].replace(/[^0-9]*/,""))
-                }
-            }
-        });
+    let connections = await this.adb.getForwardList();
+    for (let conn of connections.split('\n')) {
+      if (conn.indexOf('webview_devtools') !== -1) {
+        let params = conn.split(/\s+/);
+        if (params.length > 1) {
+          await this.adb.removePortForward(params[1].replace(/[\D]*/, '');
+        }
+      }
     }
   }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -227,8 +227,7 @@ class Chromedriver extends events.EventEmitter {
       cmd_adb = "FOR /F \"usebackq tokens=2\" %a in (`adb forward --list ^| findstr /R /C:\"webview\"`) do ( adb forward --remove %a )";
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
-      //TODO: remove adb forward resource on linux
-      cmd_adb = `echo "remove adb forward resource"`;
+      cmd_adb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
     }
     log.info(`Killing any old chromedrivers, running: ${cmd}`);
     try {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -229,17 +229,17 @@ class Chromedriver extends events.EventEmitter {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
       cmdAdb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
     }
-    const cp_exec = B.promisify(cp.exec);
+    const cpExec = B.promisify(cp.exec);
     log.debug(`Killing any old chromedrivers, running: ${cmd}`);
     try {
-      await cp_exec(cmd);
+      await cpExec(cmd);
       log.debug("Successfully cleaned up old chromedrivers");
     } catch (err) {
       log.warn("No old chromedrivers seemed to exist");
     }
-    log.debug(`Cleaning any old chromedriver port forwarding resources, running: ${cmd_adb}`);
+    log.debug(`Cleaning any old chromedriver port forwarding resources, running: ${cmdAdb}`);
     try {
-      await cp_exec(cmd_adb);
+      await cpExec(cmdAdb);
       log.debug("Successfully cleaned up adb forward resource");
     } catch (err) {
       log.warn("No adb forward resource seemed to exist");

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -50,7 +50,7 @@ class Chromedriver extends events.EventEmitter {
     }
 
     let args = ["--url-base=wd/hub", `--port=${this.proxyPort}`];
-    if (this.adb.adbPort) {
+    if (this.adb && this.adb.adbPort) {
       args = args.concat([`--adb-port=${this.adb.adbPort}`]);
     }
     if (this.cmdArgs) {
@@ -233,12 +233,14 @@ class Chromedriver extends events.EventEmitter {
       log.warn("No old chromedrivers seemed to exist");
     }
     log.debug(`Clean any old adb forwarded port socket connections`);
-    let connections = await this.adb.getForwardList();
-    for (let conn of connections) {
-      if (conn.indexOf('webview_devtools') !== -1) {
-        let params = conn.split(/\s+/);
-        if (params.length > 1) {
-          await this.adb.removePortForward(params[1].replace(/[\D]*/, ''));
+    if(this.adb){
+      let connections = await this.adb.getForwardList();
+      for (let conn of connections) {
+        if (conn.indexOf('webview_devtools') !== -1) {
+          let params = conn.split(/\s+/);
+          if (params.length > 1) {
+            await this.adb.removePortForward(params[1].replace(/[\D]*/, ''));
+          }
         }
       }
     }

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -235,7 +235,7 @@ class Chromedriver extends events.EventEmitter {
     }
     log.debug(`Clean any old adb forwarded port socket connections`);
     let connections = await this.adb.getForwardList();
-    for (let conn of connections.split('\n')) {
+    for (let conn of connections) {
       if (conn.indexOf('webview_devtools') !== -1) {
         let params = conn.split(/\s+/);
         if (params.length > 1) {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -216,6 +216,7 @@ class Chromedriver extends events.EventEmitter {
 
   async killAll () {
     let cmd;
+    let cmd_adb;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
       cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +
@@ -223,8 +224,11 @@ class Chromedriver extends events.EventEmitter {
             "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
             "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
             "/F /PID %a))";
+      cmd_adb = "FOR /F \"usebackq tokens=2\" %a in (`adb forward --list ^| findstr /R /C:\"webview\"`) do ( adb forward --remove %a )";
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
+      //TODO: remove adb forward resource on linux
+      cmd_adb = `echo "remove adb forward resource"`;
     }
     log.info(`Killing any old chromedrivers, running: ${cmd}`);
     try {
@@ -232,6 +236,12 @@ class Chromedriver extends events.EventEmitter {
       log.info("Successfully cleaned up old chromedrivers");
     } catch (err) {
       log.info("No old chromedrivers seemed to exist");
+    }
+    try {
+      await (B.promisify(cp.exec))(cmd_adb);
+      log.info("Successfully cleaned up adb forward resource");
+    } catch (err) {
+      log.info("No adb forward resource seemed to exist");
     }
   }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -233,7 +233,7 @@ class Chromedriver extends events.EventEmitter {
       log.warn("No old chromedrivers seemed to exist");
     }
     log.debug(`Clean any old adb forwarded port socket connections`);
-    if(this.adb){
+    if (this.adb) {
       let connections = await this.adb.getForwardList();
       for (let conn of connections) {
         //chromedriver will ask ADB to forward a port like "deviceId tcp:port localabstract:webview_devtools_remote_port"

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -8,7 +8,6 @@ import { retryInterval } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import B from 'bluebird';
 import { getChromedriverBinaryPath } from './install';
-import ADB from 'appium-adb';
 
 
 const log = logger.getLogger('Chromedriver');
@@ -17,11 +16,11 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 class Chromedriver extends events.EventEmitter {
   constructor (args = {}) {
-    const {host, port, executable, cmdArgs, adbPort, verbose, logPath} = args;
+    const {host, port, executable, cmdArgs, adb, verbose, logPath} = args;
     super();
     this.proxyHost = host || DEFAULT_HOST;
     this.proxyPort = port || DEFAULT_PORT;
-    this.adbPort = adbPort;
+    this.adb = adb;
     this.cmdArgs = cmdArgs;
     this.proc = null;
     this.chromedriver = executable;
@@ -30,8 +29,6 @@ class Chromedriver extends events.EventEmitter {
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
     this.verbose = verbose;
     this.logPath = logPath;
-    this.adb = new ADB();
-    this.adbPath = null;
   }
 
   async initChromedriverPath () {
@@ -53,8 +50,8 @@ class Chromedriver extends events.EventEmitter {
     }
 
     let args = ["--url-base=wd/hub", `--port=${this.proxyPort}`];
-    if (this.adbPort) {
-      args = args.concat([`--adb-port=${this.adbPort}`]);
+    if (this.adb.adbPort) {
+      args = args.concat([`--adb-port=${this.adb.adbPort}`]);
     }
     if (this.cmdArgs) {
       args = args.concat(this.cmdArgs);
@@ -65,10 +62,6 @@ class Chromedriver extends events.EventEmitter {
     if (this.logPath) {
       args = args.concat([`--log-path=${this.logPath}`]);
     }
-
-    await this.adb.getAdbWithCorrectAdbPath();
-    this.adbPath = this.adb.getAdbPath();
-	log.info(`Set adbPath as: ${this.adbPath}`);
 	
     // what are the process stdout/stderr conditions wherein we know that
     // the process has started to our satisfaction?
@@ -223,7 +216,7 @@ class Chromedriver extends events.EventEmitter {
 
   async killAll () {
     let cmd;
-    let cmdAdb;
+	let adb = this.adb;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
       cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +
@@ -231,27 +224,27 @@ class Chromedriver extends events.EventEmitter {
             "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
             "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
             "/F /PID %a))";
-      cmdAdb = "FOR /F \"usebackq tokens=2\" %a in (`" + this.adbPath + " forward --list ^| findstr /R /C:\"webview\"`) do ( " + this.adbPath + 
-			" forward --remove %a )";
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
-      cmdAdb = "for a in `" + this.adbPath + " forward --list | grep \"webview\" | awk '{print $2}'` ; do  " + this.adbPath + 
-			" forward --remove $a ; done";
     }
-    const cpExec = B.promisify(cp.exec);
     log.debug(`Killing any old chromedrivers, running: ${cmd}`);
     try {
-      await cpExec(cmd);
+      await B.promisify(cp.exec(cmd));
       log.debug("Successfully cleaned up old chromedrivers");
     } catch (err) {
       log.warn("No old chromedrivers seemed to exist");
     }
-    log.debug(`Cleaning any old chromedriver port forwarding resources, running: ${cmdAdb}`);
-    try {
-      await cpExec(cmdAdb);
-      log.debug("Successfully cleaned up adb forward resource");
-    } catch (err) {
-      log.warn("No adb forward resource seemed to exist");
+    log.debug(`Clean any old adb forwarded port socket connections`);
+    let forwardList = await adb.forwardList();
+    if(forwardList){
+        forwardList.split("\n").map(function (forwardLine){
+            if(forwardLine.indexOf("webview_devtools") >= 0){
+                forwardParams = forwardLine.split(/\s+/);
+                if(forwardParams.length >= 2){
+                    adb.removePortForward(forwardParams[1].replace(/[^0-9]*/,""))
+                }
+            }
+        });
     }
   }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -30,8 +30,8 @@ class Chromedriver extends events.EventEmitter {
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
     this.verbose = verbose;
     this.logPath = logPath;
-	this.adb = new ADB();
-	this.adbPath = null;
+    this.adb = new ADB();
+    this.adbPath = null;
   }
 
   async initChromedriverPath () {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -216,7 +216,7 @@ class Chromedriver extends events.EventEmitter {
 
   async killAll () {
     let cmd;
-	let adb = this.adb;
+    let adb = this.adb;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
       cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -62,7 +62,7 @@ class Chromedriver extends events.EventEmitter {
     if (this.logPath) {
       args = args.concat([`--log-path=${this.logPath}`]);
     }
-	
+    
     // what are the process stdout/stderr conditions wherein we know that
     // the process has started to our satisfaction?
     const startDetector = (stdout) => {
@@ -239,7 +239,7 @@ class Chromedriver extends events.EventEmitter {
       if (conn.indexOf('webview_devtools') !== -1) {
         let params = conn.split(/\s+/);
         if (params.length > 1) {
-          await this.adb.removePortForward(params[1].replace(/[\D]*/, '');
+          await this.adb.removePortForward(params[1].replace(/[\D]*/, ''));
         }
       }
     }

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -229,7 +229,6 @@ class Chromedriver extends events.EventEmitter {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
       cmdAdb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
     }
-    log.info(`Killing any old chromedrivers, running: ${cmd}`);
     const cp_exec = B.promisify(cp.exec);
     log.debug(`Killing any old chromedrivers, running: ${cmd}`);
     try {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -236,6 +236,7 @@ class Chromedriver extends events.EventEmitter {
     if(this.adb){
       let connections = await this.adb.getForwardList();
       for (let conn of connections) {
+        //chromedriver will ask ADB to forward a port like "deviceId tcp:port localabstract:webview_devtools_remote_port"
         if (conn.indexOf('webview_devtools') !== -1) {
           let params = conn.split(/\s+/);
           if (params.length > 1) {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -62,7 +62,6 @@ class Chromedriver extends events.EventEmitter {
     if (this.logPath) {
       args = args.concat([`--log-path=${this.logPath}`]);
     }
-    
     // what are the process stdout/stderr conditions wherein we know that
     // the process has started to our satisfaction?
     const startDetector = (stdout) => {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -8,6 +8,7 @@ import { retryInterval } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import B from 'bluebird';
 import { getChromedriverBinaryPath } from './install';
+import ADB from 'appium-adb';
 
 
 const log = logger.getLogger('Chromedriver');
@@ -29,6 +30,8 @@ class Chromedriver extends events.EventEmitter {
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
     this.verbose = verbose;
     this.logPath = logPath;
+	this.adb = new ADB();
+	this.adbPath = null;
   }
 
   async initChromedriverPath () {
@@ -63,6 +66,10 @@ class Chromedriver extends events.EventEmitter {
       args = args.concat([`--log-path=${this.logPath}`]);
     }
 
+    await this.adb.getAdbWithCorrectAdbPath();
+    this.adbPath = this.adb.getAdbPath();
+	log.info(`Set adbPath as: ${this.adbPath}`);
+	
     // what are the process stdout/stderr conditions wherein we know that
     // the process has started to our satisfaction?
     const startDetector = (stdout) => {
@@ -224,10 +231,12 @@ class Chromedriver extends events.EventEmitter {
             "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
             "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
             "/F /PID %a))";
-      cmdAdb = "FOR /F \"usebackq tokens=2\" %a in (`adb forward --list ^| findstr /R /C:\"webview\"`) do ( adb forward --remove %a )";
+      cmdAdb = "FOR /F \"usebackq tokens=2\" %a in (`" + this.adbPath + " forward --list ^| findstr /R /C:\"webview\"`) do ( " + this.adbPath + 
+			" forward --remove %a )";
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
-      cmdAdb = "for a in `adb forward --list | grep \"webview\" | awk '{print $2}'` ; do  adb forward --remove $a ; done";
+      cmdAdb = "for a in `" + this.adbPath + " forward --list | grep \"webview\" | awk '{print $2}'` ; do  " + this.adbPath + 
+			" forward --remove $a ; done";
     }
     const cpExec = B.promisify(cp.exec);
     log.debug(`Killing any old chromedrivers, running: ${cmd}`);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint": "gulp eslint"
   },
   "devDependencies": {
+    "appium-adb": "^2.28.0",
     "appium-gulp-plugins": "^2.1.4",
     "babel-eslint": "^7.1.1",
     "chai": "^3.0.0",

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -6,6 +6,8 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { exec } from 'teen_process';
+import ADB from 'appium-adb';
+
 
 let should = chai.should();
 chai.use(chaiAsPromised);
@@ -60,7 +62,9 @@ function buildReqRes (url, method, body) {
 describe('chromedriver binary setup', function () {
   this.timeout(20000);
   before(async () => {
-    let cd = new Chromedriver();
+    let cd = new Chromedriver({
+      adb: await ADB.createADB(),
+    });
     try {
       await cd.initChromedriverPath();
     } catch (err) {
@@ -81,7 +85,9 @@ describe('chromedriver with EventEmitter', function () {
   let cd = null;
   const caps = {browserName: 'chrome'};
   before(async () => {
-    let opts = {};
+    let opts = {
+      adb: await ADB.createADB(),
+    };
     cd = new Chromedriver(opts);
   });
   it('should start a session', async () => {
@@ -146,7 +152,10 @@ describe('chromedriver with EventEmitter', function () {
     await nextStatePromise.should.become(Chromedriver.STATE_STOPPED);
   });
   it('should throw an error when chromedriver doesnt exist', async () => {
-    let cd2 = new Chromedriver({executable: '/does/not/exist'});
+    let cd2 = new Chromedriver({
+      adb: await ADB.createADB(),
+      executable: '/does/not/exist',
+    });
     let nextErrP = nextError(cd2);
     await cd2.start({}).should.eventually.be.rejectedWith(/Trying to use/);
     let err = await nextErrP;
@@ -160,7 +169,9 @@ describe('chromedriver with async/await', function () {
   let cd = null;
   const caps = {browserName: 'chrome'};
   before(async () => {
-    let opts = {};
+    let opts = {
+      adb: await ADB.createADB(),
+    };
     cd = new Chromedriver(opts);
   });
   it('should start a session', async () => {
@@ -185,12 +196,17 @@ describe('chromedriver with async/await', function () {
     await assertNoRunningChromedrivers();
   });
   it('should throw an error during start if spawn does not work', async () => {
-    let badCd = new Chromedriver({port: 1});
+    let badCd = new Chromedriver({
+      adb: await ADB.createADB(),
+      port: 1,
+    });
     await badCd.start(caps).should.eventually.be.rejectedWith('ChromeDriver crashed during startup');
     await assertNoRunningChromedrivers();
   });
   it('should throw an error during start if session does not work', async () => {
-    let badCd = new Chromedriver();
+    let badCd = new Chromedriver({
+      adb: await ADB.createADB(),
+    });
     await badCd.start({chromeOptions: {badCap: 'foo'}})
                .should.eventually.be.rejectedWith('cannot parse capability');
     await assertNoRunningChromedrivers();


### PR DESCRIPTION
Appium start a webview session by establishing a connection between ADB with chromedriver. It kill all of chromedriver processes existed. After establishing a connection ADB will listen on a random tcp port and chromedriver will connect this port. This port was been listening after chromedriver process has been killed. The quantity of ports listened by adb will increased one by one until exhausted if switch context to webview frequently.

So I add some code into appium-chromedriver/lib/chromedriver.js file