### PR TITLE
Add error handling to port forward check

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -251,14 +251,18 @@ class Chromedriver extends events.EventEmitter {
 
     if (this.adb) {
       log.debug(`Cleaning any old adb forwarded port socket connections`);
-      for (let conn of await this.adb.getForwardList()) {
-        // chromedriver will ask ADB to forward a port like "deviceId tcp:port localabstract:webview_devtools_remote_port"
-        if (conn.indexOf('webview_devtools') !== -1) {
-          let params = conn.split(/\s+/);
-          if (params.length > 1) {
-            await this.adb.removePortForward(params[1].replace(/[\D]*/, ''));
+      try {
+        for (let conn of await this.adb.getForwardList()) {
+          // chromedriver will ask ADB to forward a port like "deviceId tcp:port localabstract:webview_devtools_remote_port"
+          if (conn.indexOf('webview_devtools') !== -1) {
+            let params = conn.split(/\s+/);
+            if (params.length > 1) {
+              await this.adb.removePortForward(params[1].replace(/[\D]*/, ''));
+            }
           }
         }
+      } catch (err) {
+        log.warn(`Unable to retrieve list of forwarded ports. Error: '${err.message}'. Continuing.`);
       }
     }
   }

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -262,7 +262,7 @@ class Chromedriver extends events.EventEmitter {
           }
         }
       } catch (err) {
-        log.warn(`Unable to retrieve list of forwarded ports. Error: '${err.message}'. Continuing.`);
+        log.warn(`Unable to clean forwarded ports. Error: '${err.message}'. Continuing.`);
       }
     }
   }


### PR DESCRIPTION
If getting the forwarded ports fails, log the error and move on.