### PR TITLE
Update CD to 2.34

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -135,16 +135,21 @@ async function conditionalInstall () {
   }
 }
 
-async function installAll () {
-  const plats = [
-    ['linux', '32'],
-    ['linux', '64'],
+function getPlatforms () {
+  let plats = [
     ['win', '32'],
   ];
+  const cdVer = parseFloat(CD_VER);
   // before 2.23 Mac version was 32 bit. After it is 64.
-  plats.push(parseFloat(CD_VER) < 2.23 ? ['mac', '32'] : ['mac', '64']);
+  plats.push(cdVer < 2.23 ? ['mac', '32'] : ['mac', '64']);
+  // 2.34 and above linux is only supporting 64 bit
+  plats.push(...(cdVer < 2.34 ? [['linux', '32'], ['linux', '64']] : [['linux', '64']]));
+  return plats;
+}
+
+async function installAll () {
   let downloads = [];
-  for (let [platform, arch] of plats) {
+  for (let [platform, arch] of getPlatforms()) {
     downloads.push(installForPlatform(CD_VER, platform, arch));
   }
   await ll(downloads);
@@ -162,4 +167,4 @@ async function doInstall () {
 }
 
 export { getChromedriverBinaryPath, install, installAll, CD_BASE_DIR,
-         getCurPlatform, conditionalInstall, doInstall };
+         getCurPlatform, conditionalInstall, doInstall, getPlatforms };

--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.33';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.34';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import request from 'request-promise';
 import { parallel as ll } from 'asyncbox';
-import { system, tempDir, fs, logger, zip } from 'appium-support';
+import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 
 const log = logger.getLogger('Chromedriver Install');
@@ -99,7 +99,7 @@ async function installForPlatform (version, platform, arch) {
   // extract downloaded zipfile to tempdir
   let tempUnzipped = path.resolve(path.dirname(tempFile.path), binarySpec);
   log.info(`Extracting ${tempFile.path} to ${tempUnzipped}`);
-  await fs.mkdir(tempUnzipped);
+  await mkdirp(tempUnzipped);
   await zip.extractAllTo(tempFile.path, tempUnzipped);
   let extractedBin = path.resolve(tempUnzipped, "chromedriver");
   if (platform === "win") {
@@ -108,8 +108,7 @@ async function installForPlatform (version, platform, arch) {
 
   // make build dirs that will hold the chromedriver binary
   log.info(`Creating ${path.resolve(CD_BASE_DIR, platform)}...`);
-  await fs.mkdir(CD_BASE_DIR);
-  await fs.mkdir(path.resolve(CD_BASE_DIR, platform));
+  await mkdirp(path.resolve(CD_BASE_DIR, platform));
 
   // copy the extracted binary to the correct build dir
   let newBin = await getChromedriverBinaryPath(platform, arch);
@@ -138,12 +137,15 @@ async function conditionalInstall () {
 function getPlatforms () {
   let plats = [
     ['win', '32'],
+    ['linux', '64'],
   ];
   const cdVer = parseFloat(CD_VER);
   // before 2.23 Mac version was 32 bit. After it is 64.
   plats.push(cdVer < 2.23 ? ['mac', '32'] : ['mac', '64']);
   // 2.34 and above linux is only supporting 64 bit
-  plats.push(...(cdVer < 2.34 ? [['linux', '32'], ['linux', '64']] : [['linux', '64']]));
+  if (cdVer < 2.34) {
+    plats.push(['linux', '32']);
+  }
   return plats;
 }
 

--- a/test/install-specs.js
+++ b/test/install-specs.js
@@ -3,8 +3,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { fs } from 'appium-support';
-import { CD_VER, CD_BASE_DIR, install, installAll, getChromedriverBinaryPath,
-         getCurPlatform } from '../lib/install';
+import { CD_BASE_DIR, install, installAll, getChromedriverBinaryPath,
+         getCurPlatform, getPlatforms } from '../lib/install';
 import Chromedriver from '../lib/chromedriver';
 
 
@@ -42,13 +42,8 @@ describe('install scripts', function () {
     this.timeout(120000);
     await assertNoPreviousDirs();
     await installAll();
-    const plats = [
-      ['linux', '32'],
-      ['linux', '64'],
-      ['win', '32']
-    ];
-    plats.push(parseFloat(CD_VER) < 2.23 ? ['mac', '32'] : ['mac', '64']);
-    for (let [platform, arch] of plats) {
+
+    for (let [platform, arch] of getPlatforms()) {
       let cdPath = await getChromedriverBinaryPath(platform, arch);
       let cdStat = await fs.stat(cdPath);
       cdStat.size.should.be.above(500000);


### PR DESCRIPTION
Details of ChromeDriver 2.34 ([full details](https://chromedriver.storage.googleapis.com/2.34/notes.txt)):
```
Supports Chrome v61-63

Changes include:
    * Supports new navigation model in Chrome v63+.
    * Fixes a bug where touch in mobile emulation doesn't work.
    * Fixes a bug in emulating Android devices.
    * Removed Timeline as a supported perf log domain type (no longer supported in Chrome).
```