### PR TITLE
Upgrade CD to 2.35

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.34';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.35';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';


### PR DESCRIPTION
[Chromedriver CHANGELOG](https://chromedriver.storage.googleapis.com/2.35/notes.txt).

Supports Chrome v62-64

Changes include:
* Supports persistent connections between client application and ChromeDriver.
* Adds more devices types for mobile emulation.
* Fixes a bug in get local storage command.
* Fixes a compatibility bug that causes JavaScript code execution to fail on some versions of Chrome.
* Uses absolute time in log file.