### PR TITLE
Get 2.37

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.36';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.37';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-base-driver": "^2.0.0",
+    "appium-base-driver": "^2.25.0",
     "appium-support": "^2.8.0",
     "asyncbox": "^2.0.2",
     "babel-runtime": "=5.8.24",
-    "bluebird": "^2.10.2",
+    "bluebird": "^3.5.1",
     "continuation-local-storage": "^3.1.4",
     "is-os": "^1.0.0",
     "lodash": "^4.17.4",
     "request": "^2.57.0",
-    "request-promise": "^1.0.1",
-    "source-map-support": "^0.3.2",
+    "request-promise": "^4.2.2",
+    "source-map-support": "^0.5.4",
     "teen_process": "^1.3.1",
     "through": "^2.3.7"
   },
@@ -60,8 +60,8 @@
   "devDependencies": {
     "appium-gulp-plugins": "^2.2.1",
     "babel-eslint": "^7.1.1",
-    "chai": "^3.0.0",
-    "chai-as-promised": "^5.1.0",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^3.10.2",
     "eslint-config-appium": "^2.1.0",
     "eslint-plugin-babel": "^3.3.0",
@@ -69,7 +69,7 @@
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1",
     "gulp": "^3.9.0",
-    "mocha": "^2.4.5",
+    "mocha": "^5.0.5",
     "pre-commit": "^1.1.3"
   }
 }


### PR DESCRIPTION
----------ChromeDriver v2.37 (2018-03-16)----------
Supports Chrome v64-66
Resolved issue 2304: Test ChromeDriverSiteIsolation.testCanClickOOPIF fails on Chrome v66 for all desktop platforms [[Pri-1]]
Resolved issue 1940: Many window command endpoints are unimplemented in Chromedriver [[Pri-2]]
Resolved issue 1937: Get element rect is not implemented [[Pri-2]]
Resolved issue 2329: ChromeDriver does not allow value of 0 for extensionLoadTimeout option [[Pri-2]]