### PR TITLE
Fix Chromedriver version parsing bug

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -115,9 +115,9 @@ class Chromedriver extends events.EventEmitter {
     const cds = (await asyncmap(executables, async function (executable) {
       try {
         const {stdout} = await exec(executable, ['--version']);
-        const match = /ChromeDriver\s(\d+\.\d+\.\d+)\s/.exec(stdout);
+        const match = /ChromeDriver\s(\d+\.\d+)\.\d+\s/.exec(stdout);
         if (match) {
-          const version = parseFloat(match[1]);
+          const version = match[1];
           return {
             executable,
             version,
@@ -127,7 +127,7 @@ class Chromedriver extends events.EventEmitter {
       } catch (ign) {}
     }))
       .filter((cd) => !!cd)
-      .sort((a, b) => a.version <= b.version ? 1 : -1);
+      .sort((a, b) => semver.gte(semver.coerce(b.version), semver.coerce(a.version)) ? 1 : -1);
     if (_.isEmpty(cds)) {
       log.errorAndThrow(`No Chromedriver found`);
     }

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -151,7 +151,9 @@ describe('chromedriver', function () {
             });
 
         const chromedrivers = await cd.getChromedrivers({});
-        _.map(chromedrivers, cd => cd.version).should.eql(['2.36', '2.35', '2.34', '2.33', '2.32', '2.31', '2.30']);
+        for (const [cd, expectedVersion] of _.zip(chromedrivers, ['2.36', '2.35', '2.34', '2.33', '2.32', '2.31', '2.30'])) {
+          cd.version.should.eql(expectedVersion);
+        }
       });
 
       it('should find most recent binary from a number of possibilities when chrome is too new', async function () {

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -6,7 +6,7 @@ import chai from 'chai';
 import { fs } from 'appium-support';
 import * as tp from 'teen_process';
 import path from 'path';
-
+import _ from 'lodash';
 
 chai.should();
 
@@ -107,6 +107,51 @@ describe('chromedriver', function () {
 
         const binPath = await cd.getCompatibleChromedriver();
         binPath.should.eql('/path/to/chromedriver-36');
+      });
+
+      it('should correctly determine Chromedriver versions', async function () {
+        sandbox.stub(fs, 'glob')
+          .returns([
+            '/path/to/chromedriver-36',
+            '/path/to/chromedriver-35',
+            '/path/to/chromedriver-34',
+            '/path/to/chromedriver-33',
+            '/path/to/chromedriver-32',
+            '/path/to/chromedriver-31',
+            '/path/to/chromedriver-30',
+          ]);
+        sandbox.stub(tp, 'exec')
+          .onCall(0)
+            .returns({
+              stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(1)
+            .returns({
+              stdout: 'ChromeDriver 2.35.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(2)
+            .returns({
+              stdout: 'ChromeDriver 2.34.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(3)
+            .returns({
+              stdout: 'ChromeDriver 2.33.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(4)
+            .returns({
+              stdout: 'ChromeDriver 2.32.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(5)
+            .returns({
+              stdout: 'ChromeDriver 2.31.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            })
+          .onCall(6)
+            .returns({
+              stdout: 'ChromeDriver 2.30.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+            });
+
+        const chromedrivers = await cd.getChromedrivers({});
+        _.map(chromedrivers, cd => cd.version).should.eql(['2.36', '2.35', '2.34', '2.33', '2.32', '2.31', '2.30']);
       });
 
       it('should find most recent binary from a number of possibilities when chrome is too new', async function () {


### PR DESCRIPTION
Currently, the Chromedriver version is stored as a float. This mishandles versions ending in "0", though. For example, version "2.30" becomes "2.3" when cast to a float.

To resolve the issue, version is stored as a string. A unit test is also added to prevent regressions.

Co-authored-by: Umut Umzugur <@umutuzgur>