### PR TITLE
Update handling of chrome version

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -57,6 +57,7 @@ const CHROMEDRIVER_CHROME_MAPPING = {
   '2.1': '27.0.1453',
   '2.0': '27.0.1453',
 };
+const CHROME_BUNDLE_ID = 'com.android.chrome';
 const WEBVIEW_BUNDLE_IDS = [
   'com.google.android.webview',
   'com.android.webview',
@@ -145,6 +146,33 @@ class Chromedriver extends events.EventEmitter {
       log.debug(`    ${cd.executable} (minimum Chrome version '${cd.minCDVersion ? cd.minCDVersion : 'Unknown'}')`);
     }
     return cds;
+  }
+
+  async getChromeVersion () {
+    let chromeVersion;
+
+    // try out webviews when no bundle id is sent in
+    if (!this.bundleId) {
+      // default to the generic Chrome bundle
+      this.bundleId = CHROME_BUNDLE_ID;
+
+      // we have a webview of some sort, so try to find the bundle version
+      for (const bundleId of WEBVIEW_BUNDLE_IDS) {
+        chromeVersion = await getChromeVersion(this.adb, bundleId);
+        if (chromeVersion) {
+          this.bundleId = bundleId;
+          break;
+        }
+      }
+    }
+
+    // if we do not have a chrome version, it must not be a webview
+    if (!chromeVersion) {
+      chromeVersion = await getChromeVersion(this.adb, this.bundleId);
+    }
+
+    // make sure it is semver, so later checks won't fail
+    chromeVersion = chromeVersion ? semver.coerce(chromeVersion) : null;
   }
 
   async getCompatibleChromedriver () {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -57,6 +57,10 @@ const CHROMEDRIVER_CHROME_MAPPING = {
   '2.1': '27.0.1453',
   '2.0': '27.0.1453',
 };
+const WEBVIEW_BUNDLE_IDS = [
+  'com.google.android.webview',
+  'com.android.webview',
+];
 
 class Chromedriver extends events.EventEmitter {
   constructor (args = {}) {
@@ -67,7 +71,7 @@ class Chromedriver extends events.EventEmitter {
       port = DEFAULT_PORT,
       executable,
       executableDir = getChromedriverDir(),
-      bundleId = 'com.android.chrome',
+      bundleId,
       mappingPath,
       cmdArgs,
       adb,
@@ -151,13 +155,29 @@ class Chromedriver extends events.EventEmitter {
     const mapping = await this.getMapping();
     const cds = await this.getChromedrivers(mapping);
 
-    const chromeVersion = semver.coerce(await getChromeVersion(this.adb, this.bundleId));
+    let chromeVersion;
+    if (this.bundleId) {
+      chromeVersion = await getChromeVersion(this.adb, this.bundleId);
+    } else {
+      // we have a webview of some sort, so try to find the bundle version
+      for (const bundleId of WEBVIEW_BUNDLE_IDS) {
+        chromeVersion = await getChromeVersion(this.adb, bundleId);
+        if (chromeVersion) {
+          this.bundleId = bundleId;
+          break;
+        }
+      }
+    }
+    chromeVersion = chromeVersion ? semver.coerce(chromeVersion) : null;
+
     if (!chromeVersion) {
       // unable to get the chrome version
       let cd = cds[0];
       log.warn(`Unable to discover Chrome version. Using Chromedriver ${cd.version} at '${cd.executable}'`);
       return cd.executable;
     }
+
+    log.debug(`Found Chrome bundle '${this.bundleId}' version '${chromeVersion}'`);
 
     if (semver.gt(chromeVersion, _.values(mapping)[0]) &&
         !_.isUndefined(cds[0]) && _.isUndefined(cds[0].minCDVersion)) {
@@ -181,8 +201,8 @@ class Chromedriver extends events.EventEmitter {
     }
 
     const binPath = workingCds[0].executable;
-    log.debug(`Found ${workingCds.length} Chromedriver executable${workingCds.length === 1 ? '' : 's'}\n` +
-              `capable of automating Chrome '${chromeVersion}'. ` +
+    log.debug(`Found ${workingCds.length} Chromedriver executable${workingCds.length === 1 ? '' : 's'} ` +
+              `capable of automating Chrome '${chromeVersion}'.\n` +
               `Choosing the most recent, '${binPath}'.`);
     log.debug('If a specific version is required, specify it with the `chromedriverExecutable`' +
               'desired capability.');


### PR DESCRIPTION
If no bundle id is sent in, try to find the correct chrome-webview package version, so this will work for webviews as well as actual Chrome.

This is a breaking change.