### PR TITLE
Update CD to 2.38

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -18,6 +18,7 @@ const log = logger.getLogger('Chromedriver');
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
+  '2.38': '65.0.3325',
   '2.37': '64.0.3282',
   '2.36': '63.0.3239',
   '2.35': '62.0.3202',

--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.37';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.38';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';


### PR DESCRIPTION
```
----------ChromeDriver v2.38 (2018-04-17)----------
Supports Chrome v65-67
Resolved issue 2354: The chromedriver crashes/lose connection when navigate to gmail [[Pri-0]]
Resolved issue 2381: Unknown session ID and cannot determine loading status [[Pri-1]]
Resolved issue 2198: ChromeDriver 2.34 doesn't wait until iframe content loads after switching into iframe [[Pri-2]]
Resolved issue 2142: unknown error: Element is not clickable at point - after updating chrome browser and chrome driver to latest version [[Pri-2]]
```