### PR TITLE
Add CD 2.39

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -18,6 +18,7 @@ const log = logger.getLogger('Chromedriver');
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
+  '2.39': '66.0.3359',
   '2.38': '65.0.3325',
   '2.37': '64.0.3282',
   '2.36': '63.0.3239',

--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.38';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.39';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';


### PR DESCRIPTION
```
Supports Chrome v66-68
Resolved issue 2436: ChromeDriver for Android does not provide useful error message for old adb version [[Pri-1]]
Resolved issue 2431: ChromeDriver tests that close Windows are flaky [[Pri-1]]
Resolved issue 2259: Click on component into an Iframe (with container padding > 0) is not working [[Pri-1]]
Resolved issue 2161: ChromeDriver remote debug port reservation race conditions [[Pri-2]]
Resolved issue 2420: Get Alert Text is not returning spec compliant error codes [[Pri-2]]
Resolved issue 2369: Clean up state of androidUseRunningApp feature [[Pri-2]]
Resolved issue 2406: Minimize/Maximize window need a w3c compliant endpoints [[Pri-]]
```