### PR TITLE
Bump CD to 2.40

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -18,6 +18,7 @@ const log = logger.getLogger('Chromedriver');
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
+  '2.40': '66.0.3359',
   '2.39': '66.0.3359',
   '2.38': '65.0.3325',
   '2.37': '64.0.3282',

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -7,8 +7,7 @@ import { system, fs, logger } from 'appium-support';
 import { retryInterval, asyncmap } from 'asyncbox';
 import { SubProcess, exec } from 'teen_process';
 import B from 'bluebird';
-import { getChromedriverBinaryPath, getChromedriverDir } from './install';
-import { getChromeVersion } from './utils';
+import { getChromeVersion, getChromedriverDir, getChromedriverBinaryPath } from './utils';
 import semver from 'semver';
 import _ from 'lodash';
 
@@ -60,15 +59,21 @@ const CHROMEDRIVER_CHROME_MAPPING = {
   '2.1': '27.0.1453',
   '2.0': '27.0.1453',
 };
-const MOST_RECENT_CHROMEDRIVER = _.keys(CHROMEDRIVER_CHROME_MAPPING)
-  .map((v) => semver.coerce(v))
-  .sort(semver.rcompare)
-  .map((v) => `${semver.major(v)}.${semver.minor(v)}`)[0];
 const CHROME_BUNDLE_ID = 'com.android.chrome';
 const WEBVIEW_BUNDLE_IDS = [
   'com.google.android.webview',
   'com.android.webview',
 ];
+
+function getMostRecentChromedriver (mapping = CHROMEDRIVER_CHROME_MAPPING) {
+  if (_.isEmpty(mapping)) {
+    throw new Error('Unable to get most recent Chromedriver from empty mapping');
+  }
+  return _.keys(mapping)
+    .map(semver.coerce)
+    .sort(semver.rcompare)
+    .map((v) => `${semver.major(v)}.${semver.minor(v)}`)[0];
+}
 
 class Chromedriver extends events.EventEmitter {
   constructor (args = {}) {
@@ -494,5 +499,5 @@ Chromedriver.STATE_ONLINE = 'online';
 Chromedriver.STATE_STOPPING = 'stopping';
 Chromedriver.STATE_RESTARTING = 'restarting';
 
-export { Chromedriver, CHROMEDRIVER_CHROME_MAPPING, MOST_RECENT_CHROMEDRIVER };
+export { Chromedriver, CHROMEDRIVER_CHROME_MAPPING, getMostRecentChromedriver };
 export default Chromedriver;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -60,6 +60,10 @@ const CHROMEDRIVER_CHROME_MAPPING = {
   '2.1': '27.0.1453',
   '2.0': '27.0.1453',
 };
+const MOST_RECENT_CHROMEDRIVER = _.keys(CHROMEDRIVER_CHROME_MAPPING)
+  .map((v) => semver.coerce(v))
+  .sort(semver.rcompare)
+  .map((v) => `${semver.major(v)}.${semver.minor(v)}`)[0];
 const CHROME_BUNDLE_ID = 'com.android.chrome';
 const WEBVIEW_BUNDLE_IDS = [
   'com.google.android.webview',
@@ -175,7 +179,7 @@ class Chromedriver extends events.EventEmitter {
     }
 
     // make sure it is semver, so later checks won't fail
-    chromeVersion = chromeVersion ? semver.coerce(chromeVersion) : null;
+    return chromeVersion ? semver.coerce(chromeVersion) : null;
   }
 
   async getCompatibleChromedriver () {
@@ -186,20 +190,7 @@ class Chromedriver extends events.EventEmitter {
     const mapping = await this.getMapping();
     const cds = await this.getChromedrivers(mapping);
 
-    let chromeVersion;
-    if (this.bundleId) {
-      chromeVersion = await getChromeVersion(this.adb, this.bundleId);
-    } else {
-      // we have a webview of some sort, so try to find the bundle version
-      for (const bundleId of WEBVIEW_BUNDLE_IDS) {
-        chromeVersion = await getChromeVersion(this.adb, bundleId);
-        if (chromeVersion) {
-          this.bundleId = bundleId;
-          break;
-        }
-      }
-    }
-    chromeVersion = chromeVersion ? semver.coerce(chromeVersion) : null;
+    const chromeVersion = await this.getChromeVersion();
 
     if (!chromeVersion) {
       // unable to get the chrome version
@@ -503,4 +494,5 @@ Chromedriver.STATE_ONLINE = 'online';
 Chromedriver.STATE_STOPPING = 'stopping';
 Chromedriver.STATE_RESTARTING = 'restarting';
 
+export { Chromedriver, CHROMEDRIVER_CHROME_MAPPING, MOST_RECENT_CHROMEDRIVER };
 export default Chromedriver;

--- a/lib/install.js
+++ b/lib/install.js
@@ -7,7 +7,7 @@ import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.39';
+const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.40';
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,11 +3,14 @@ import path from 'path';
 import request from 'request-promise';
 import { parallel as ll } from 'asyncbox';
 import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
+import { MOST_RECENT_CHROMEDRIVER } from './chromedriver';
 
 
 const log = logger.getLogger('Chromedriver Install');
 
-const CD_VER = process.env.npm_config_chromedriver_version || process.env.CHROMEDRIVER_VERSION || '2.40';
+const CD_VER = process.env.npm_config_chromedriver_version ||
+               process.env.CHROMEDRIVER_VERSION ||
+               MOST_RECENT_CHROMEDRIVER;
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,31 +3,21 @@ import path from 'path';
 import request from 'request-promise';
 import { parallel as ll } from 'asyncbox';
 import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
-import { MOST_RECENT_CHROMEDRIVER } from './chromedriver';
+import { getMostRecentChromedriver } from './chromedriver';
+import { CD_BASE_DIR, getChromedriverBinaryPath, getCurPlatform,
+         getChromedriverDir } from './utils';
 
 
 const log = logger.getLogger('Chromedriver Install');
 
 const CD_VER = process.env.npm_config_chromedriver_version ||
                process.env.CHROMEDRIVER_VERSION ||
-               MOST_RECENT_CHROMEDRIVER;
+               getMostRecentChromedriver();
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';
-const CD_BASE_DIR = path.resolve(__dirname, "..", "..", "chromedriver");
 const CD_PLATS = ["linux", "win", "mac"];
 const CD_ARCHS = ["32", "64"];
-
-function getCurPlatform () {
-  return system.isWindows() ? "win" : (system.isMac() ? "mac" : "linux");
-}
-
-function getChromedriverDir (platform = null) {
-  if (!platform) {
-    platform = getCurPlatform();
-  }
-  return path.resolve(CD_BASE_DIR, platform);
-}
 
 async function getArchAndPlatform () {
   let arch = await system.arch();
@@ -39,23 +29,6 @@ async function getArchAndPlatform () {
     arch = '32';
   }
   return {arch, platform};
-}
-
-async function getChromedriverBinaryPath (platform = null, arch = null) {
-  if (!platform) {
-    platform = getCurPlatform();
-  }
-  const baseDir = getChromedriverDir(platform);
-  let ext = "";
-  if (platform === "win") {
-    ext = ".exe";
-  } else if (platform === "linux") {
-    if (!arch) {
-      arch = await system.arch();
-    }
-    ext = "_" + arch;
-  }
-  return path.resolve(baseDir, `chromedriver${ext}`);
 }
 
 function getDownloadUrl (version, platform, arch) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,41 @@
+import { system } from 'appium-support';
+import path from 'path';
+
+
+const CD_BASE_DIR = path.resolve(__dirname, "..", "..", "chromedriver");
+
 async function getChromeVersion (adb, bundleId) {
   const {versionName} = await adb.getPackageInfo(bundleId);
   return versionName;
 }
 
-export { getChromeVersion };
+function getChromedriverDir (platform = null) {
+  if (!platform) {
+    platform = getCurPlatform();
+  }
+  return path.resolve(CD_BASE_DIR, platform);
+}
+
+async function getChromedriverBinaryPath (platform = null, arch = null) {
+  if (!platform) {
+    platform = getCurPlatform();
+  }
+  const baseDir = getChromedriverDir(platform);
+  let ext = "";
+  if (platform === "win") {
+    ext = ".exe";
+  } else if (platform === "linux") {
+    if (!arch) {
+      arch = await system.arch();
+    }
+    ext = "_" + arch;
+  }
+  return path.resolve(baseDir, `chromedriver${ext}`);
+}
+
+function getCurPlatform () {
+  return system.isWindows() ? "win" : (system.isMac() ? "mac" : "linux");
+}
+
+export { getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,
+         getCurPlatform, CD_BASE_DIR };

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -1,4 +1,4 @@
-import Chromedriver from '../lib/chromedriver';
+import { Chromedriver, getMostRecentChromedriver } from '../lib/chromedriver';
 import * as install from '../lib/install';
 import * as utils from '../lib/utils';
 import sinon from 'sinon';
@@ -22,7 +22,7 @@ describe('chromedriver', function () {
   describe('getCompatibleChromedriver', function () {
     describe('desktop', function () {
       it('should find generic binary', async function () {
-        sandbox.stub(install, 'getChromedriverBinaryPath')
+        sandbox.stub(utils, 'getChromedriverBinaryPath')
           .returns('/path/to/chromedriver');
 
         const cd = new Chromedriver({});
@@ -251,6 +251,40 @@ describe('chromedriver', function () {
         const binPath = await cd.getCompatibleChromedriver();
         binPath.should.eql('/path/to/chromedriver-42');
       });
+    });
+  });
+
+  describe('getMostRecentChromedriver', function () {
+    it('should get a value by default', function () {
+      getMostRecentChromedriver().should.be.a.string;
+    });
+    it('should get the most recent version', function () {
+      const mapping = {
+        '2.12': '36.0.1985',
+        '2.11': '36.0.1985',
+        '2.10': '33.0.1751',
+        '2.9': '31.0.1650',
+        '2.8': '30.0.1573',
+        '2.7': '30.0.1573',
+        '2.6': '29.0.1545',
+      };
+      getMostRecentChromedriver(mapping).should.eql('2.12');
+    });
+    it('should handle broken semver', function () {
+      const mapping = {
+        '2.12': '36.0.1985',
+        'v2.11': '36.0.1985',
+        '2.10.0.0': '33.0.1751',
+        '2.9-beta': '31.0.1650',
+        '2.8': '30.0.1573',
+        '2.7': '30.0.1573',
+        '2.6': '29.0.1545',
+      };
+      getMostRecentChromedriver(mapping).should.eql('2.12');
+    });
+    it('should fail for empty mapping', function () {
+      (() => getMostRecentChromedriver({}))
+        .should.throw('Unable to get most recent Chromedriver from empty mapping');
     });
   });
 });


### PR DESCRIPTION
```
----------ChromeDriver v2.40 (2018-06-07)----------
Supports Chrome v66-68
Resolved issue 2446: Regression: Chromedriver 2.39 hangs on open when user-data-dir is specified and exists [[Pri-1]]
Resolved issue  779: Make ChromeDriver able to listen on requests from IPv6. [[Pri-1]]
Resolved issue 2339: Chromedriver couldn't find the Android file using valid file path [[Pri-2]]
Resolved issue 2307: /session/:sessionId/send_command and /session/:sessionId/send_command_and_get_result should be changed to be proper extension commands [[Pri-]]
```