### PR TITLE
Webview bundleid

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -249,9 +249,12 @@ class Chromedriver extends events.EventEmitter {
     // the executable might be set (if passed in)
     // or we might want to use the basic one installed with this driver
     // or we want to figure out the best one
-    this.chromedriver = this.chromedriver || this.useSystemExecutable
-      ? await getChromedriverBinaryPath()
-      : await this.getCompatibleChromedriver();
+    if (!this.chromedriver) {
+      this.chromedriver = this.useSystemExecutable
+        ? await getChromedriverBinaryPath()
+        : await this.getCompatibleChromedriver();
+    }
+
     if (!await fs.exists(this.chromedriver)) {
       throw new Error(`Trying to use a chromedriver binary at the path ` +
                       `${this.chromedriver}, but it doesn't exist!`);

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -163,6 +163,11 @@ class Chromedriver extends events.EventEmitter {
   async getChromeVersion () {
     let chromeVersion;
 
+    // on Android 7+ webviews are backed by the main Chrome, not the system webview
+    if (this.adb && await this.adb.getApiLevel() >= 24) {
+      this.bundleId = CHROME_BUNDLE_ID;
+    }
+
     // try out webviews when no bundle id is sent in
     if (!this.bundleId) {
       // default to the generic Chrome bundle

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -82,6 +82,7 @@ class Chromedriver extends events.EventEmitter {
     const {
       host = DEFAULT_HOST,
       port = DEFAULT_PORT,
+      useSystemExecutable = false,
       executable,
       executableDir = getChromedriverDir(),
       bundleId,
@@ -97,6 +98,7 @@ class Chromedriver extends events.EventEmitter {
     this.adb = adb;
     this.cmdArgs = cmdArgs;
     this.proc = null;
+    this.useSystemExecutable = useSystemExecutable;
     this.chromedriver = executable;
     this.executableDir = executableDir;
     this.mappingPath = mappingPath;
@@ -244,7 +246,12 @@ class Chromedriver extends events.EventEmitter {
   async initChromedriverPath () {
     if (this.executableVerified) return; //eslint-disable-line curly
 
-    this.chromedriver = this.chromedriver || await this.getCompatibleChromedriver();
+    // the executable might be set (if passed in)
+    // or we might want to use the basic one installed with this driver
+    // or we want to figure out the best one
+    this.chromedriver = this.chromedriver || this.useSystemExecutable
+      ? await getChromedriverBinaryPath()
+      : await this.getCompatibleChromedriver();
     if (!await fs.exists(this.chromedriver)) {
       throw new Error(`Trying to use a chromedriver binary at the path ` +
                       `${this.chromedriver}, but it doesn't exist!`);

--- a/lib/install.js
+++ b/lib/install.js
@@ -49,7 +49,7 @@ function validatePlatform (platform, arch) {
 
 async function installForPlatform (version, platform, arch) {
   if (version === 'LATEST') {
-    version = (await request.get({uri: CD_CDN + '/LATEST_RELEASE'})).trim();
+    version = (await request.get({uri: `${CD_CDN}/LATEST_RELEASE`})).trim();
   }
   validatePlatform(platform, arch);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,7 @@ async function getChromedriverBinaryPath (platform = getCurPlatform(), arch = nu
   } else if (platform === 'linux') {
     ext = `_${arch || await system.arch()}`;
   }
+
   return path.resolve(baseDir, `chromedriver${ext}`);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,39 +2,30 @@ import { system } from 'appium-support';
 import path from 'path';
 
 
-const CD_BASE_DIR = path.resolve(__dirname, "..", "..", "chromedriver");
+const CD_BASE_DIR = path.resolve(__dirname, '..', '..', 'chromedriver');
 
 async function getChromeVersion (adb, bundleId) {
   const {versionName} = await adb.getPackageInfo(bundleId);
   return versionName;
 }
 
-function getChromedriverDir (platform = null) {
-  if (!platform) {
-    platform = getCurPlatform();
-  }
+function getChromedriverDir (platform = getCurPlatform()) {
   return path.resolve(CD_BASE_DIR, platform);
 }
 
-async function getChromedriverBinaryPath (platform = null, arch = null) {
-  if (!platform) {
-    platform = getCurPlatform();
-  }
+async function getChromedriverBinaryPath (platform = getCurPlatform(), arch = null) {
   const baseDir = getChromedriverDir(platform);
-  let ext = "";
-  if (platform === "win") {
-    ext = ".exe";
-  } else if (platform === "linux") {
-    if (!arch) {
-      arch = await system.arch();
-    }
-    ext = "_" + arch;
+  let ext = '';
+  if (platform === 'win') {
+    ext = '.exe';
+  } else if (platform === 'linux') {
+    ext = `_${arch || await system.arch()}`;
   }
   return path.resolve(baseDir, `chromedriver${ext}`);
 }
 
 function getCurPlatform () {
-  return system.isWindows() ? "win" : (system.isMac() ? "mac" : "linux");
+  return system.isWindows() ? 'win' : (system.isMac() ? 'mac' : 'linux');
 }
 
 export { getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,

--- a/test/chromedriver-e2e-specs.js
+++ b/test/chromedriver-e2e-specs.js
@@ -147,7 +147,7 @@ describe('chromedriver with EventEmitter', function () {
     await cd.killAll();
     await nextStatePromise.should.become(Chromedriver.STATE_STOPPED);
   });
-  it('should throw an error when chromedriver doesnt exist', async function () {
+  it('should throw an error when chromedriver does not exist', async function () {
     let cd2 = new Chromedriver({
       executable: '/does/not/exist',
     });

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -37,9 +37,7 @@ describe('chromedriver', function () {
       before(function () {
         cd = new Chromedriver({
           adb: {
-            getApiLevel: async function () { // eslint-disable-line
-              return 25;
-            }
+            getApiLevel: () => 25,
           },
         });
       });
@@ -194,7 +192,9 @@ describe('chromedriver', function () {
 
       it('should search specified directory if provided', async function () {
         const cd = new Chromedriver({
-          adb: {},
+          adb: {
+            getApiLevel: () => 25,
+          },
           executableDir: '/some/local/dir/for/chromedrivers',
         });
 
@@ -216,7 +216,9 @@ describe('chromedriver', function () {
 
       it('should use alternative mapping if provided', async function () {
         const cd = new Chromedriver({
-          adb: {},
+          adb: {
+            getApiLevel: () => 25,
+          },
           mappingPath: path.resolve(__dirname, '..', '..', 'test', 'fixtures', 'alt-mapping.json'),
         });
 
@@ -237,7 +239,9 @@ describe('chromedriver', function () {
 
       it('should use alternative mapping if provided even if semver is broken', async function () {
         const cd = new Chromedriver({
-          adb: {},
+          adb: {
+            getApiLevel: () => 25,
+          },
           mappingPath: path.resolve(__dirname, '..', '..', 'test', 'fixtures', 'alt-mapping-nonsemver.json'),
         });
 

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -36,7 +36,11 @@ describe('chromedriver', function () {
       let getChromedriverBinaryPathSpy;
       before(function () {
         cd = new Chromedriver({
-          adb: {},
+          adb: {
+            getApiLevel: async function () { // eslint-disable-line
+              return 25;
+            }
+          },
         });
       });
       beforeEach(function () {


### PR DESCRIPTION
Android 7+ use Chrome for backing webviews, not the system webview.

Add an argument to circumvent all discovery and use the CD version installed by the package.