### PR TITLE
Update to v2.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ When a new [Chromedriver](http://chromedriver.chromium.org/) version is released
 the details will be [here](http://chromedriver.chromium.org/downloads). Which
 Chromedriver this package selects is based on the `CHROMEDRIVER_CHROME_MAPPING`
 in `lib/chromedriver`. Add a new entry to the top, with the correct version number
-and a random, but low, "minimum chrome version". To install, build then re-install
+and a random, but low, "minimum chrome version" (this will make it so that while
+this version is chosen, the test in the next step will fail for the right reason
+and give us the correct value to put here). To install, build then re-install
 the package:
 ```
 npm run build
@@ -137,6 +139,7 @@ Error: Failed to start Chromedriver session: A new session could not be created.
   Details: session not created exception: Chrome version must be >= 67.0.3396.0
 ```
 Take the number (e.g., here, `67.0.3396.0`) and put the first three parts
-(`67.0.3396`) into the `CHROMEDRIVER_CHROME_MAPPING`.
+(`67.0.3396`) into the `CHROMEDRIVER_CHROME_MAPPING`, replacing the random value
+inserted at the beginning of this process.
 
 Commit, push, and pull request!

--- a/README.md
+++ b/README.md
@@ -113,3 +113,30 @@ npm run watch
 ```
 npm test
 ```
+
+## Upgrading Chromedriver Version
+
+When a new [Chromedriver](http://chromedriver.chromium.org/) version is released,
+the details will be [here](http://chromedriver.chromium.org/downloads). Which
+Chromedriver this package selects is based on the `CHROMEDRIVER_CHROME_MAPPING`
+in `lib/chromedriver`. Add a new entry to the top, with the correct version number
+and a random, but low, "minimum chrome version". To install, build then re-install
+the package:
+```
+npm run build
+npm install
+```
+Then link to `appium-uiautomator2-driver` and run the "url" test from that package:
+```
+npm run mocha -- -t 900000 --recursive -R spec build/test/functional/commands/general/url-e2e-specs.js --exit
+```
+This **will** fail, but in the error message will be the actual minimum Chrome
+version for this version of Chromedriver:
+```
+Error: Failed to start Chromedriver session: A new session could not be created.
+  Details: session not created exception: Chrome version must be >= 67.0.3396.0
+```
+Take the number (e.g., here, `67.0.3396.0`) and put the first three parts
+(`67.0.3396`) into the `CHROMEDRIVER_CHROME_MAPPING`.
+
+Commit, push, and pull request!

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -18,6 +18,8 @@ const log = logger.getLogger('Chromedriver');
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
+  // Chromedriver version: minumum Chrome version
+  '2.41': '67.0.3396',
   '2.40': '66.0.3359',
   '2.39': '66.0.3359',
   '2.38': '65.0.3325',


### PR DESCRIPTION
```
----------ChromeDriver v2.41 (2018-07-27)----------
Supports Chrome v67-69
Resolved issue 2458: Chromedriver fails to start with whitelisted-ips option [[Pri-1]]
Resolved issue 2379: Returned capabilities should include remote debugging port [[Pri-2]]
Resolved issue 1005: driver.manage().window().getSize() is not implemented on Android [[Pri-2]]
Resolved issue 2474: desktop launcher error messages are not readable by users [[Pri-]]
Resolved issue 2496: Fail fast when not able to start binary [[Pri-]]
Resolved issue 1990: Close Window return value does not conform with spec [[Pri-]]
```
https://chromedriver.storage.googleapis.com/index.html?path=2.41/