### PR TITLE
Clean up install script logging

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -2,13 +2,16 @@ import _ from 'lodash';
 import path from 'path';
 import request from 'request-promise';
 import { parallel as ll } from 'asyncbox';
-import { system, tempDir, fs, logger, zip, mkdirp } from 'appium-support';
+import { system, tempDir, fs, zip, mkdirp } from 'appium-support';
 import { getMostRecentChromedriver } from './chromedriver';
 import { CD_BASE_DIR, getChromedriverBinaryPath, getCurPlatform,
          getChromedriverDir } from './utils';
+import logger from 'fancy-log';
 
 
-const log = logger.getLogger('Chromedriver Install');
+function log (line) {
+  logger(`[Chromedriver Install] ${line}`);
+}
 
 const CD_VER = process.env.npm_config_chromedriver_version ||
                process.env.CHROMEDRIVER_VERSION ||
@@ -16,8 +19,8 @@ const CD_VER = process.env.npm_config_chromedriver_version ||
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';
-const CD_PLATS = ["linux", "win", "mac"];
-const CD_ARCHS = ["32", "64"];
+const CD_PLATS = ['linux', 'win', 'mac'];
+const CD_ARCHS = ['32', '64'];
 
 async function getArchAndPlatform () {
   let arch = await system.arch();
@@ -43,7 +46,7 @@ function validatePlatform (platform, arch) {
     throw new Error(`Invalid arch: ${arch}`);
   }
   if (arch === "64" && platform !== "linux" && platform !== 'mac') {
-    throw new Error("Only linux has a 64-bit version of Chromedriver");
+    throw new Error('Only linux has a 64-bit version of Chromedriver');
   }
 }
 
@@ -55,58 +58,59 @@ async function installForPlatform (version, platform, arch) {
 
   const url = getDownloadUrl(version, platform, arch);
 
-  log.info(`Installing Chromedriver version '${version}' for platform '${platform}' and architecture '${arch}'`);
+  log(`Installing Chromedriver version '${version}' for platform '${platform}' and architecture '${arch}'`);
 
   // set up a temp file to download the chromedriver zipfile to
-  let binarySpec = `chromedriver_${platform}${arch}`;
-  log.info(`Opening temp file to write ${binarySpec} to...`);
-  let tempFile = await tempDir.open({
+  const binarySpec = `chromedriver_${platform}${arch}`;
+  log(`Opening temp file to write '${binarySpec}' to...`);
+  const tempFile = await tempDir.open({
     prefix: binarySpec,
     suffix: '.zip'
   });
+  log(`Opened temp file '${tempFile.path}'`);
 
   // actually download the zipfile and write it with appropriate perms
-  log.info(`Downloading ${url}...`);
-  let body = await request.get({url, encoding: 'binary'});
-  log.info(`Writing binary content to ${tempFile.path}...`);
+  log(`Downloading ${url}...`);
+  const body = await request.get({url, encoding: 'binary'});
+  log(`Writing binary content to ${tempFile.path}...`);
   await fs.writeFile(tempFile.path, body, {encoding: 'binary'});
   await fs.chmod(tempFile.path, 0o0644);
 
   // extract downloaded zipfile to tempdir
-  let tempUnzipped = path.resolve(path.dirname(tempFile.path), binarySpec);
-  log.info(`Extracting ${tempFile.path} to ${tempUnzipped}`);
+  const tempUnzipped = path.resolve(path.dirname(tempFile.path), binarySpec);
+  log(`Extracting ${tempFile.path} to ${tempUnzipped}`);
   await mkdirp(tempUnzipped);
   await zip.extractAllTo(tempFile.path, tempUnzipped);
-  let extractedBin = path.resolve(tempUnzipped, "chromedriver");
+  let extractedBin = path.resolve(tempUnzipped, 'chromedriver');
   if (platform === "win") {
     extractedBin += ".exe";
   }
 
   // make build dirs that will hold the chromedriver binary
-  log.info(`Creating ${path.resolve(CD_BASE_DIR, platform)}...`);
+  log(`Creating ${path.resolve(CD_BASE_DIR, platform)}...`);
   await mkdirp(path.resolve(CD_BASE_DIR, platform));
 
   // copy the extracted binary to the correct build dir
-  let newBin = await getChromedriverBinaryPath(platform, arch);
-  log.info(`Copying unzipped binary, reading from ${extractedBin}...`);
-  let binContents = await fs.readFile(extractedBin, {encoding: 'binary'});
-  log.info(`Writing to ${newBin}...`);
+  const newBin = await getChromedriverBinaryPath(platform, arch);
+  log(`Copying unzipped binary, reading from ${extractedBin}...`);
+  const binContents = await fs.readFile(extractedBin, {encoding: 'binary'});
+  log(`Writing to ${newBin}...`);
   await fs.writeFile(newBin, binContents, {encoding: 'binary', mode: 0o755});
-  log.info(`${newBin} successfully put in place`);
+  log(`${newBin} successfully put in place`);
 }
 
 async function install () {
-  let {arch, platform} = await getArchAndPlatform();
+  const {arch, platform} = await getArchAndPlatform();
   await installForPlatform(CD_VER, platform, arch);
 }
 
 async function conditionalInstall () {
-  let {arch, platform} = await getArchAndPlatform();
-  let binPath = await getChromedriverBinaryPath(platform, arch);
+  const {arch, platform} = await getArchAndPlatform();
+  const binPath = await getChromedriverBinaryPath(platform, arch);
   if (!await fs.exists(binPath)) {
     await installForPlatform(CD_VER, platform, arch);
   } else {
-    log.info(`No need to install chromedriver, ${binPath} exists`);
+    log(`No need to install chromedriver, ${binPath} exists`);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,21 +30,20 @@
     "asyncbox": "^2.0.2",
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
-    "continuation-local-storage": "^3.1.4",
-    "is-os": "^1.0.0",
+    "fancy-log": "^1.3.2",
     "lodash": "^4.17.4",
     "request": "^2.57.0",
     "request-promise": "^4.2.2",
     "semver": "^5.5.0",
     "source-map-support": "^0.5.5",
-    "teen_process": "^1.3.1",
-    "through": "^2.3.7"
+    "teen_process": "^1.3.1"
   },
   "pre-commit": [
     "precommit-msg",
     "precommit-test"
   ],
   "scripts": {
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "prepublish": "gulp prepublish",
     "install": "node install-npm.js",
     "test": "gulp once",


### PR DESCRIPTION
Remove some unused dependencies, and shift to using `fancy-log`, so the install logs blend into the npm logs.