### PR TITLE
add chrome driver 2.41

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -18,6 +18,7 @@ const log = logger.getLogger('Chromedriver');
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
+  '2.41': '67.0.3360',
   '2.40': '66.0.3359',
   '2.39': '66.0.3359',
   '2.38': '65.0.3325',


### PR DESCRIPTION
When I described https://github.com/appium/appium/pull/11128 , I found we could add `2.41` driver.
https://chromium.googlesource.com/chromium/src/+refs

I searched for `2.40` in this repository, but I couldn't find the number other places. Is this enough to add the new version?