### PR TITLE
Update to CD 2.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,18 +128,31 @@ the package:
 npm run build
 npm install
 ```
-Then link to `appium-uiautomator2-driver` and run the "url" test from that package:
+To get the minimum version of Chrome needed for the new Chromedriver, in one
+shell run Chromedriver
+```shell
+./chromedriver/<PLATFORM>/chromedriver[.exe] --verbose
 ```
-npm run mocha -- -t 900000 --recursive -R spec build/test/functional/commands/general/url-e2e-specs.js --exit
+And in anther shell, create a session by running the [curl](https://curl.haxx.se/) command
+```shell
+curl \
+  -d '{"desiredCapabilities":{"chromeOptions":{"androidPackage":"com.android.chrome","androidDeviceSerial":"emulator-5554"}}}' \
+  -H "Content-Type: application/json" \
+  -XPOST http://localhost:9515/session
 ```
 This **will** fail, but in the error message will be the actual minimum Chrome
 version for this version of Chromedriver:
+```json
+{
+  "sessionId": "55dcde971731f3d1ce04b54d7664069c",
+  "status": 33,
+  "value": {
+    "message": "session not created: Chrome version must be >= 68.0.3440.0\n  (Driver info: chromedriver=2.42.591059 (a3d9684d10d61aa0c45f6723b327283be1ebaad8),platform=Mac OS X 10.13.6 x86_64)"
+  }
+}
 ```
-Error: Failed to start Chromedriver session: A new session could not be created.
-  Details: session not created exception: Chrome version must be >= 67.0.3396.0
-```
-Take the number (e.g., here, `67.0.3396.0`) and put the first three parts
-(`67.0.3396`) into the `CHROMEDRIVER_CHROME_MAPPING`, replacing the random value
+Take the number (e.g., here, `68.0.3440.0`) and put the first three parts
+(`68.0.3440.0`) into the `CHROMEDRIVER_CHROME_MAPPING`, replacing the random value
 inserted at the beginning of this process.
 
 Commit, push, and pull request!

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -19,6 +19,7 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '2.42': '68.0.3440',
   '2.41': '67.0.3396',
   '2.40': '66.0.3359',
   '2.39': '66.0.3359',


### PR DESCRIPTION
Chromedriver 2.42 has [been released](https://chromedriver.storage.googleapis.com/index.html?path=2.42/):
```txt
----------ChromeDriver v2.42 (2018-09-13)----------
Supports Chrome v68-70
Resolved issue 2144: Test testClickElement from MobileEmulationCapabilityTest class fails on Chromium for all platforms [[Pri-1]]
Resolved issue 2566: whitelisted-ips not working with ipv4 [[Pri-1]]
Resolved issue 2541: chromedriver v2.41 fails to start with whitelisted-ips flag on macOS [[Pri-1]]
Resolved issue 2057: Set Timeouts is not implemented [[Pri-1]]
Resolved issue 1938: Take element screenshot not implemented in Chromedriver [[Pri-2]]
Resolved issue 2550: chromedriver ignores PATH when searching for chrome binary [[Pri-2]]
Resolved issue 1993: Fullscreen Window command not spec compliant [[Pri-2]]
Resolved issue 2501: Implement log-replay functionality [[Pri-2]]
Resolved issue 2552: Some error codes are not standard compliant [[Pri-2]]
Resolved issue  669: console.log with multiple arguments not handled properly [[Pri-2]]
Resolved issue 2545: Getting "unknown error: getting size failed to return x" for SVG rect [[Pri-2]]
Resolved issue 2571: chromedriver 2.35 ~ 2.41 - touch emulation not working (swipe) [[Pri-]]
```

Also simplify instructions for getting the minimum version of Chrome.