### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-chromedriver
-*.log
-coverage

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -168,7 +168,7 @@ class Chromedriver extends events.EventEmitter {
         return logError(err);
       }
 
-      const match = /ChromeDriver\s+([\d\.]+)/i.exec(stdout);
+      const match = /ChromeDriver\s+([\d.]+)/i.exec(stdout);
       if (!match) {
         return logError({message: 'Cannot parse the version string', stdout, stderr});
       }

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -69,6 +69,10 @@ const WEBVIEW_BUNDLE_IDS = [
   'com.android.webview',
 ];
 
+const CD_VER = process.env.npm_config_chromedriver_version ||
+               process.env.CHROMEDRIVER_VERSION ||
+               getMostRecentChromedriver();
+
 function getMostRecentChromedriver (mapping = CHROMEDRIVER_CHROME_MAPPING) {
   if (_.isEmpty(mapping)) {
     throw new Error('Unable to get most recent Chromedriver from empty mapping');
@@ -140,7 +144,7 @@ class Chromedriver extends events.EventEmitter {
   async getChromedrivers (mapping) {
     // go through the versions available
     const executables = await fs.glob(`${this.executableDir}/*`);
-    log.debug(`Found ${executables.length} executable${executables.length === 1 ? '': 's'} ` +
+    log.debug(`Found ${executables.length} executable${executables.length === 1 ? '' : 's'} ` +
       `in '${this.executableDir}'`);
     const cds = (await asyncmap(executables, async function (executable) {
       const logError = ({message, stdout = null, stderr = null}) => {
@@ -346,7 +350,7 @@ class Chromedriver extends events.EventEmitter {
         // also print chromedriver version to logs
         // will output something like
         //  Starting ChromeDriver 2.33.506106 (8a06c39c4582fbfbab6966dbb1c38a9173bfb1a2) on port 9515
-        match = /Starting ChromeDriver ([\.\d]+)/.exec(out);
+        match = /Starting ChromeDriver ([.\d]+)/.exec(out);
         if (match) {
           log.debug(`Chromedriver version: '${match[1]}'`);
         }
@@ -543,5 +547,7 @@ Chromedriver.STATE_ONLINE = 'online';
 Chromedriver.STATE_STOPPING = 'stopping';
 Chromedriver.STATE_RESTARTING = 'restarting';
 
-export { Chromedriver, CHROMEDRIVER_CHROME_MAPPING, getMostRecentChromedriver };
+export {
+  Chromedriver, CHROMEDRIVER_CHROME_MAPPING, getMostRecentChromedriver, CD_VER,
+};
 export default Chromedriver;

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,9 +3,9 @@ import path from 'path';
 import request from 'request-promise';
 import { parallel as ll } from 'asyncbox';
 import { system, tempDir, fs, zip, mkdirp } from 'appium-support';
-import { getMostRecentChromedriver } from './chromedriver';
+import { CD_VER } from './chromedriver';
 import { CD_BASE_DIR, getChromedriverBinaryPath, getCurPlatform,
-         getChromedriverDir } from './utils';
+         getPlatforms } from './utils';
 import logger from 'fancy-log';
 
 
@@ -13,9 +13,6 @@ function log (line) {
   logger(`[Chromedriver Install] ${line}`);
 }
 
-const CD_VER = process.env.npm_config_chromedriver_version ||
-               process.env.CHROMEDRIVER_VERSION ||
-               getMostRecentChromedriver();
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl ||
                process.env.CHROMEDRIVER_CDNURL ||
                'https://chromedriver.storage.googleapis.com';
@@ -114,21 +111,6 @@ async function conditionalInstall () {
   }
 }
 
-function getPlatforms () {
-  let plats = [
-    ['win', '32'],
-    ['linux', '64'],
-  ];
-  const cdVer = parseFloat(CD_VER);
-  // before 2.23 Mac version was 32 bit. After it is 64.
-  plats.push(cdVer < 2.23 ? ['mac', '32'] : ['mac', '64']);
-  // 2.34 and above linux is only supporting 64 bit
-  if (cdVer < 2.34) {
-    plats.push(['linux', '32']);
-  }
-  return plats;
-}
-
 async function installAll () {
   let downloads = [];
   for (let [platform, arch] of getPlatforms()) {
@@ -148,6 +130,4 @@ async function doInstall () {
   }
 }
 
-export { getChromedriverBinaryPath, install, installAll, CD_BASE_DIR,
-         getCurPlatform, conditionalInstall, doInstall, getPlatforms,
-         getChromedriverDir };
+export { install, installAll, conditionalInstall, doInstall };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 import { system } from 'appium-support';
 import path from 'path';
+import { CD_VER } from './chromedriver';
 
 
 const CD_BASE_DIR = path.resolve(__dirname, '..', '..', 'chromedriver');
@@ -29,5 +30,22 @@ function getCurPlatform () {
   return system.isWindows() ? 'win' : (system.isMac() ? 'mac' : 'linux');
 }
 
-export { getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,
-         getCurPlatform, CD_BASE_DIR };
+function getPlatforms () {
+  let plats = [
+    ['win', '32'],
+    ['linux', '64'],
+  ];
+  const cdVer = parseFloat(CD_VER);
+  // before 2.23 Mac version was 32 bit. After it is 64.
+  plats.push(cdVer < 2.23 ? ['mac', '32'] : ['mac', '64']);
+  // 2.34 and above linux is only supporting 64 bit
+  if (cdVer < 2.34) {
+    plats.push(['linux', '32']);
+  }
+  return plats;
+}
+
+export {
+  getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,
+  getCurPlatform, getPlatforms, CD_BASE_DIR,
+};

--- a/package.json
+++ b/package.json
@@ -24,11 +24,19 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "install-npm.js",
+    "lib",
+    "build/index.js",
+    "build/install-npm.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-support": "^2.8.0",
     "asyncbox": "^2.0.2",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "fancy-log": "^1.3.2",
     "lodash": "^4.17.4",
@@ -44,7 +52,7 @@
   ],
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "install": "node install-npm.js",
     "test": "gulp once",
     "watch": "gulp watch",
@@ -59,32 +67,22 @@
     "lint:fix": "gulp eslint --fix"
   },
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.1",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.9.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.0.5",
     "pre-commit": "^1.1.3",
     "sinon": "^6.0.0"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/chromedriver-e2e-specs.js
+++ b/test/chromedriver-e2e-specs.js
@@ -81,7 +81,7 @@ describe('chromedriver with EventEmitter', function () {
   this.timeout(120000);
   let cd = null;
   const caps = {browserName: 'chrome'};
-  before(async function () {
+  before(function () {
     cd = new Chromedriver({});
   });
   it('should start a session', async function () {
@@ -163,7 +163,7 @@ describe('chromedriver with async/await', function () {
   this.timeout(120000);
   let cd = null;
   const caps = {browserName: 'chrome'};
-  before(async function () {
+  before(function () {
     cd = new Chromedriver({});
   });
   it('should start a session', async function () {

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -1,5 +1,4 @@
 import { Chromedriver, getMostRecentChromedriver } from '../lib/chromedriver';
-import * as install from '../lib/install';
 import * as utils from '../lib/utils';
 import sinon from 'sinon';
 import chai from 'chai';
@@ -7,6 +6,7 @@ import { fs } from 'appium-support';
 import * as tp from 'teen_process';
 import path from 'path';
 import _ from 'lodash';
+
 
 chai.should();
 
@@ -42,7 +42,7 @@ describe('chromedriver', function () {
         });
       });
       beforeEach(function () {
-        getChromedriverBinaryPathSpy = sandbox.spy(install, 'getChromedriverBinaryPath');
+        getChromedriverBinaryPathSpy = sandbox.spy(utils, 'getChromedriverBinaryPath');
       });
       afterEach(function () {
         getChromedriverBinaryPathSpy.called.should.be.false;

--- a/test/install-e2e-specs.js
+++ b/test/install-e2e-specs.js
@@ -3,8 +3,9 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { fs } from 'appium-support';
-import { CD_BASE_DIR, install, installAll, getChromedriverBinaryPath,
-         getCurPlatform, getPlatforms } from '../lib/install';
+import { install, installAll } from '../lib/install';
+import { CD_BASE_DIR, getChromedriverBinaryPath, getPlatforms,
+         getCurPlatform } from '../lib/utils';
 import Chromedriver from '../lib/chromedriver';
 
 


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.