### PR TITLE
Upgrade to 2.43

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -19,6 +19,7 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '2.43': '69.0.3497',
   '2.42': '68.0.3440',
   '2.41': '67.0.3396',
   '2.40': '66.0.3359',


### PR DESCRIPTION
```
Supports Chrome v69-71

Changes include:
Fixed Parsing of proxy configuration is not standard compliant
Fixed Launch app command is flaky
Fixed Screenshot of element inside iFrame is taken incorrectly
Added ChromeDriver supports window resizing over a remote connection
Fixed Error codes are not handled in Clear element
Fixed Not waiting until element is visible
Fixed Get element property is not implemented
Fixed Switch to Frame is not spec compliant
Fixed Execute Async Script does not return spec compliant error codes
Fixed Execute Script does not return spec compliant error codes
Fixed Error code in ExecuteGet is not conformant with spec
Fixed Send Alert Text is not returning spec compliant error codes
Fixed clear() on an input type="date" pretends element is not user-editable
Fixed Chromedriver gets window handle for the tab which is opened manually
Fixed Allow append or start a new log file for chromedriver
Fixed New Session does not invoke w3c mode if flag is in firstMatch
```