### PR TITLE
return chrome version on device to clients when startSession fails

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -395,15 +395,18 @@ class Chromedriver extends events.EventEmitter {
         await this.proc.stop();
       }
 
+      let message = '';
       // often the user's Chrome version is too low for the version of Chromedriver
       if (e.message.indexOf('Chrome version must be') !== -1) {
-        log.error('Unable to automate Chrome version because it is too old for this version of Chromedriver.');
+        message = message.concat('Unable to automate Chrome version because it is too old for this version of Chromedriver.\n');
         if (webviewVersion) {
-          log.error(`Chrome version on device: ${webviewVersion}`);
+          message = message.concat(`Chrome version on device: ${webviewVersion}\n`);
         }
-        log.error(`Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'`);
+        message = message.concat(`Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'\n`);
       }
-      log.errorAndThrow(e);
+
+      message = message.concat(e);
+      log.errorAndThrow(message);
     }
   }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -69,6 +69,7 @@ const WEBVIEW_BUNDLE_IDS = [
   'com.google.android.webview',
   'com.android.webview',
 ];
+const CHROMEDRIVER_TUTORIAL = 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md';
 
 const CD_VER = process.env.npm_config_chromedriver_version ||
                process.env.CHROMEDRIVER_VERSION ||
@@ -264,8 +265,7 @@ class Chromedriver extends events.EventEmitter {
 
     if (_.isEmpty(workingCds)) {
       log.errorAndThrow(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
-                        `See https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md ` +
-                        `for more details.`);
+                        `See ${CHROMEDRIVER_TUTORIAL} for more details.`);
     }
 
     const binPath = workingCds[0].executable;
@@ -397,12 +397,12 @@ class Chromedriver extends events.EventEmitter {
 
       let message = '';
       // often the user's Chrome version is too low for the version of Chromedriver
-      if (e.message.indexOf('Chrome version must be') !== -1) {
+      if (e.message.includes('Chrome version must be')) {
         message += 'Unable to automate Chrome version because it is too old for this version of Chromedriver.\n';
         if (webviewVersion) {
-          message += `Chrome version on device: ${webviewVersion}\n`;
+          message += `Chrome version on the device: ${webviewVersion}\n`;
         }
-        message += `Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'\n`;
+        message += `Visit '${CHROMEDRIVER_TUTORIAL}' to troubleshoot the problem.\n`;
       }
 
       message += e.message;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -398,14 +398,14 @@ class Chromedriver extends events.EventEmitter {
       let message = '';
       // often the user's Chrome version is too low for the version of Chromedriver
       if (e.message.indexOf('Chrome version must be') !== -1) {
-        message = message.concat('Unable to automate Chrome version because it is too old for this version of Chromedriver.\n');
+        message += 'Unable to automate Chrome version because it is too old for this version of Chromedriver.\n';
         if (webviewVersion) {
-          message = message.concat(`Chrome version on device: ${webviewVersion}\n`);
+          message += `Chrome version on device: ${webviewVersion}\n`;
         }
-        message = message.concat(`Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'\n`);
+        message += `Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'\n`;
       }
 
-      message = message.concat(e);
+      message += e.message;
       log.errorAndThrow(message);
     }
   }


### PR DESCRIPTION
Currently, we can see below error message when establishing Chromedriver connection fails.

```
[debug] [Chromedriver][Chromedriver] Unable to automate Chrome version because it is too old for this version of Chromedriver.
 Changed state to 'stopped'
[Chromedriver] Chrome version on device: Chrome/61.0.3163.98
[Chromedriver] Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'
[Chromedriver] Error: Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
[Chromedriver]   (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
[Chromedriver]     at Object.wrappedLogger.errorAndThrow (/Users/kazuaki/GitHub/appium/node_modules/appium-support/lib/logging.js:78:13)
[Chromedriver]     at /Users/kazuaki/GitHub/appium/node_modules/appium-chromedriver/lib/chromedriver.js:458:13
[Chromedriver]     at Generator.throw (<anonymous>)
[Chromedriver]     at asyncGeneratorStep (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
[Chromedriver]     at _throw (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:29:9)
[Chromedriver]     at <anonymous>
[debug] [UiAutomator2] Deleting UiAutomator2 session
[debug] [UiAutomator2] Deleting UiAutomator2 server session
```

Below is a client-side log.

```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
  (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
from UnknownError: An unknown server-side error occurred while processing the command. Original error: Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
```

This cause is an imcompatible version issue between Chromedriver and WebView chrome. We must coordinate them to fix it.
We must dig into the server log to make sure why this happens.

By in this PR, I'd like to show the chrome version on the test device to client-side. It helps users understand they must coordinate chrome versions without digging into server logs.

What do you think?

## After this PR

Users can compare current chrome version on device in error message in client side.

- client
```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to automate Chrome version because it is too old for this version of Chromedriver.
        Chrome version on the device: Chrome/61.0.3163.98
        Visit 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md' to troubleshoot the problem.
        Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
          (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
            UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to automate Chrome version because it is too old for this version of Chromedriver.
            Chrome version on the device: Chrome/61.0.3163.98
            Visit 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md' to troubleshoot the problem.
            Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
              (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
                at getResponseForW3CError (/Users/kazuaki/GitHub/appium/node_modules/appium-base-driver/lib/protocol/errors.js:826:9)
                at /Users/kazuaki/GitHub/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:450:37
                at Generator.next (<anonymous>)
                at asyncGeneratorStep (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
                at _next (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
                at <anonymous>
...
```

or

```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to automate Chrome version because it is too old for this version of Chromedriver.
Chrome version on the device: Chrome/61.0.3163.98
Visit 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md' to troubleshoot the problem.
Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
  (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
from UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to automate Chrome version because it is too old for this version of Chromedriver.
```


- server

```
[debug] [UiAutomator2] Deleting UiAutomator2 session
[debug] [UiAutomator2] Deleting UiAutomator2 server session
[debug] [JSONWP Proxy] Matched '/' to command name 'deleteSession'
[debug] [JSONWP Proxy] Proxying [DELETE /] to [DELETE http://localhost:8200/wd/hub/session/5a9807db-a919-4e37-bbf5-b86d137fca2e] with no body
[debug] [JSONWP Proxy] Got response with status 200: "{\"sessionId\":\"5a9807db-a919-4e37-bbf5-b86d137fca2e\",\"status\":0,\"value\":\"Session deleted\"}"
[debug] [UiAutomator2] Resetting IME to 'io.appium.android.ime/.UnicodeIME'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell ime set io.appium.android.ime/.UnicodeIME'
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am force-stop com.android.chrome'
[debug] [Logcat] Stopping logcat capture
[debug] [ADB] Removing forwarded port socket connection: 8200 
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 forward --remove tcp\:8200'
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1541329961359 (20:12:41 GMT+0900 (JST))
[debug] [W3C] Encountered internal error running command: Error: Unable to automate Chrome version because it is too old for this version of Chromedriver.
[debug] [W3C] Chrome version on the device: Chrome/61.0.3163.98
[debug] [W3C] Please see 'https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md'
[debug] [W3C] Failed to start Chromedriver session: A new session could not be created. Details: session not created: Chrome version must be >= 69.0.3497.0
[debug] [W3C]   (Driver info: chromedriver=2.43.600229 (3fae4d0cda5334b4f533bede5a4787f7b832d052),platform=Mac OS X 10.14.0 x86_64)
[debug] [W3C]     at Object.wrappedLogger.errorAndThrow (/Users/kazuaki/GitHub/appium/node_modules/appium-support/lib/logging.js:78:13)
[debug] [W3C]     at /Users/kazuaki/GitHub/appium/node_modules/appium-chromedriver/lib/chromedriver.js:409:11
[debug] [W3C]     at Generator.next (<anonymous>)
[debug] [W3C]     at asyncGeneratorStep (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
[debug] [W3C]     at _next (/Users/kazuaki/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
[debug] [W3C]     at <anonymous>
[HTTP] <-- POST /wd/hub/session 500 114398 ms - 1776
```