### PR TITLE
Fix handling of low CD versions

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -75,6 +75,8 @@ const CD_VER = process.env.npm_config_chromedriver_version ||
                process.env.CHROMEDRIVER_VERSION ||
                getMostRecentChromedriver();
 
+const CD_VERSION_TIMEOUT = 5000;
+
 function getMostRecentChromedriver (mapping = CHROMEDRIVER_CHROME_MAPPING) {
   if (_.isEmpty(mapping)) {
     throw new Error('Unable to get most recent Chromedriver from empty mapping');
@@ -165,12 +167,20 @@ class Chromedriver extends events.EventEmitter {
       let stdout;
       let stderr;
       try {
-        ({stdout, stderr} = await exec(executable, ['--version']));
+        ({stdout, stderr} = await exec(executable, ['--version'], {
+          timeout: CD_VERSION_TIMEOUT,
+        }));
       } catch (err) {
-        return logError(err);
+        if (!(err.message || '').includes('timed out') && !(err.stdout || '').includes('Starting ChromeDriver')) {
+          return logError(err);
+        }
+
+        // if this has timed out,it has actually started Chromedriver,
+        // in which case there will also be the version string in the output
+        stdout = err.stdout;
       }
 
-      const match = /ChromeDriver\s+([\d.]+)/i.exec(stdout);
+      const match = /ChromeDriver\s+\(?v?([\d.]+)\)?/i.exec(stdout); // https://regex101.com/r/zpj5wA/1
       if (!match) {
         return logError({message: 'Cannot parse the version string', stdout, stderr});
       }

--- a/lib/install.js
+++ b/lib/install.js
@@ -5,8 +5,9 @@ import { parallel as ll } from 'asyncbox';
 import { system, tempDir, fs, zip, mkdirp } from 'appium-support';
 import { CD_VER } from './chromedriver';
 import { CD_BASE_DIR, getChromedriverBinaryPath, getCurPlatform,
-         getPlatforms } from './utils';
+         getPlatforms, MAC_32_ONLY } from './utils';
 import logger from 'fancy-log';
+import semver from 'semver';
 
 
 function log (line) {
@@ -22,10 +23,12 @@ const CD_ARCHS = ['32', '64'];
 async function getArchAndPlatform () {
   let arch = await system.arch();
   let platform = getCurPlatform();
-  if (platform !== 'linux' && platform !== 'mac' && arch === '64') {
+  if (platform !== 'linux' && platform !== 'mac') {
     arch = '32';
   }
-  if (platform === 'mac' && parseFloat(CD_VER) < 2.23) {
+
+  const cdVer = semver.coerce(CD_VER);
+  if (platform === 'mac' && semver.lt(cdVer, MAC_32_ONLY)) {
     arch = '32';
   }
   return {arch, platform};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,13 @@
 import { system } from 'appium-support';
 import path from 'path';
 import { CD_VER } from './chromedriver';
+import semver from 'semver';
 
 
 const CD_BASE_DIR = path.resolve(__dirname, '..', '..', 'chromedriver');
+
+const MAC_32_ONLY = semver('2.23.0');
+const LINUX_32_ONLY = semver('2.34.0');
 
 async function getChromeVersion (adb, bundleId) {
   const {versionName} = await adb.getPackageInfo(bundleId);
@@ -35,11 +39,11 @@ function getPlatforms () {
     ['win', '32'],
     ['linux', '64'],
   ];
-  const cdVer = parseFloat(CD_VER);
+  const cdVer = semver.coerce(CD_VER);
   // before 2.23 Mac version was 32 bit. After it is 64.
-  plats.push(cdVer < 2.23 ? ['mac', '32'] : ['mac', '64']);
+  plats.push(semver.lt(cdVer, MAC_32_ONLY) ? ['mac', '32'] : ['mac', '64']);
   // 2.34 and above linux is only supporting 64 bit
-  if (cdVer < 2.34) {
+  if (semver.lt(cdVer, LINUX_32_ONLY)) {
     plats.push(['linux', '32']);
   }
   return plats;
@@ -47,5 +51,5 @@ function getPlatforms () {
 
 export {
   getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,
-  getCurPlatform, getPlatforms, CD_BASE_DIR,
+  getCurPlatform, getPlatforms, CD_BASE_DIR, MAC_32_ONLY, LINUX_32_ONLY,
 };


### PR DESCRIPTION
Two changes:
1. On install, lexical compare breaks down for low versions of CD (since 2.9 is, lexically, greater that 2.10). Shift to semver to fix this.
1. When checking versions by running `chromedriver --version` at a certain point the flag is not respected and CD just launches, which means the whole process hangs indefinitely. 
    1. Add a timeout
    1. On timeout, check if it started, in which case the version string is in the standard output
    1. Update the regular expression to handle the different format of the string in this case (see https://regex101.com/r/zpj5wA/1).