### PR TITLE
Add disableBuildCheck opt

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -101,6 +101,7 @@ class Chromedriver extends events.EventEmitter {
       adb,
       verbose,
       logPath,
+      disableBuildCheck,
     } = args;
 
     this.proxyHost = host;
@@ -118,6 +119,7 @@ class Chromedriver extends events.EventEmitter {
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
     this.verbose = verbose;
     this.logPath = logPath;
+    this.disableBuildCheck = !!disableBuildCheck;
   }
 
   async getMapping () {
@@ -312,6 +314,9 @@ class Chromedriver extends events.EventEmitter {
     }
     if (this.logPath) {
       args = args.concat([`--log-path=${this.logPath}`]);
+    }
+    if (this.disableBuildCheck) {
+      args = args.concat(['--disable-build-check']);
     }
     args = args.concat(['--verbose']);
     // what are the process stdout/stderr conditions wherein we know that


### PR DESCRIPTION
Chromium has an unsupported command line option `--disable-build-check` (https://chromium.googlesource.com/chromium/src.git/+/master/chrome/test/chromedriver/chrome_launcher.cc#248) which gets rid of the check for Chrome version on the device. Since the check is a massive pain, give the option to turn that flag on.