### PR TITLE
Update to CD 2.44

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -19,6 +19,7 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '2.44': '69.0.3497',
   '2.43': '69.0.3497',
   '2.42': '68.0.3440',
   '2.41': '67.0.3396',


### PR DESCRIPTION
Chromedriver 2.44 [was released](https://chromedriver.storage.googleapis.com/2.44/notes.txt):
```
----------ChromeDriver v2.44 (2018-11-19)----------
Supports Chrome v69-71
Resolved issue 2522: Test ChromeDriverTest.testWindowMaximize is failing on Mac build bot on Waterfall [[Pri-2]]
Resolved issue 2615: Incorrect 'alert open error' for window handle call [[Pri-2]]
Resolved issue 2649: Element Send Keys should get "text" property in W3C mode [[Pri-2]]
Resolved issue 1995: XML special case of Is Element Enabled is not handled as per spec [[Pri-2]]
Resolved issue 1994: XML special case of Get Element CSS Value is not handled as per spec [[Pri-2]]
Resolved issue 2655: Set Window Rect needs to check for invalid input [[Pri-3]]
Resolved issue 2597: Support new unhandledPromptBehavior modes [[Pri-3]]
```