### PR TITLE
Improved a way of killing driver on Windows

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -514,11 +514,7 @@ class Chromedriver extends events.EventEmitter {
     let cmd;
     if (system.isWindows()) {
       // js hint cannot handle backticks, even escaped, within template literals
-      cmd = "FOR /F \"usebackq tokens=5\" %a in (`netstat -nao ^| " +
-            "findstr /R /C:\"" + this.proxyPort + " \"`) do (" +
-            "FOR /F \"usebackq\" %b in (`TASKLIST /FI \"PID eq %a\" ^| " +
-            "findstr /I chromedriver.exe`) do (IF NOT %b==\"\" TASKKILL " +
-            "/F /PID %a))";
+      cmd = `wmic process where "commandline like '%chromedriver.exe%--port=${this.proxyPort}%'" delete`;
     } else {
       cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
     }

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -511,13 +511,9 @@ class Chromedriver extends events.EventEmitter {
   }
 
   async killAll () {
-    let cmd;
-    if (system.isWindows()) {
-      // js hint cannot handle backticks, even escaped, within template literals
-      cmd = `wmic process where "commandline like '%chromedriver.exe%--port=${this.proxyPort}%'" delete`;
-    } else {
-      cmd = `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
-    }
+    let cmd = system.isWindows()
+      ? `wmic process where "commandline like '%chromedriver.exe%--port=${this.proxyPort}%'" delete`
+      : `pkill -15 -f "${this.chromedriver}.*--port=${this.proxyPort}"`;
     log.debug(`Killing any old chromedrivers, running: ${cmd}`);
     try {
       await (B.promisify(cp.exec))(cmd);


### PR DESCRIPTION
The current solution is based on loops and difficult to read syntax.
Moreover, sometimes used command hangs up for some time and makes execution really slow. 
To improve and simplify that process on Windows machines, new command based on `wmic` for killing `chromedriver` is proposed.