### PR TITLE
Add Chromedriver 2.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,21 +119,30 @@ npm test
 When a new [Chromedriver](http://chromedriver.chromium.org/) version is released,
 the details will be [here](http://chromedriver.chromium.org/downloads). Which
 Chromedriver this package selects is based on the `CHROMEDRIVER_CHROME_MAPPING`
-in `lib/chromedriver`. Add a new entry to the top, with the correct version number
-and a random, but low, "minimum chrome version" (this will make it so that while
-this version is chosen, the test in the next step will fail for the right reason
-and give us the correct value to put here). To install, build then re-install
-the package:
+in `lib/chromedriver`.
+
+To add a new entry, you must know the Chromedriver version and the minimum version
+of Chrome which it is capable of automating. Starting with Chromedriver
+[2.46](https://chromedriver.storage.googleapis.com/index.html?path=2.46/) the
+executable has a command line flag `--minimum-chrome-version` to get the latter.
+So, you just need to download the Chromedriver version, and then run it
 ```
-npm run build
-npm install
+path/to/chromedriver[.exe] --minimum-chrome-version
 ```
-To get the minimum version of Chrome needed for the new Chromedriver, in one
+The output will be something like `minimum supported Chrome version: 71.0.3578.0`.
+
+Add a new entry to the top of `CHROMEDRIVER_CHROME_MAPPING` in `lib/chromedriver`,
+consisting of the version of Chromedriver and the first three parts of the
+minimum Chrome version.
+
+If the command line flag is not available, the minimum Chrome version can be
+obtained by attempting to run a session against a low version of Chrome. In one
 shell run Chromedriver
 ```shell
-./chromedriver/<PLATFORM>/chromedriver[.exe] --verbose
+path/to/chromedriver[.exe] --verbose
 ```
-And in anther shell, create a session by running the [curl](https://curl.haxx.se/) command
+And in anther shell, create a session by running the [curl](https://curl.haxx.se/)
+command
 ```shell
 curl \
   -d '{"desiredCapabilities":{"chromeOptions":{"androidPackage":"com.android.chrome","androidDeviceSerial":"emulator-5554"}}}' \
@@ -152,7 +161,7 @@ version for this version of Chromedriver:
 }
 ```
 Take the number (e.g., here, `68.0.3440.0`) and put the first three parts
-(`68.0.3440.0`) into the `CHROMEDRIVER_CHROME_MAPPING`, replacing the random value
-inserted at the beginning of this process.
+(`68.0.3440`) into the `CHROMEDRIVER_CHROME_MAPPING` along with the version of
+Chromedriver being added.
 
 Commit, push, and pull request!

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -19,6 +19,7 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '2.46': '71.0.3578',
   '2.45': '70.0.0',
   '2.44': '69.0.3497',
   '2.43': '69.0.3497',


### PR DESCRIPTION
Chromedriver 2.46 has been released:
```
----------ChromeDriver v2.46 (2019-02-01)----------
Supports Chrome v71-73
Resolved issue 2728: Is Element Displayed command does not work correctly with v0 shadow DOM inserts [[Pri-1]]
Resolved issue  755: /session/:sessionId/doubleclick only generates one set of mousedown/mouseup/click events [[Pri-2]]
Resolved issue 2744: Execute Script returns wrong error code when JavaScript returns a cyclic data structure [[Pri-2]]
Resolved issue 1529: OnResponse behavior can lead to port exhaustion [[Pri-2]]
Resolved issue 2736: Close Window command should handle user prompts based on session capabilities [[Pri-2]]
Resolved issue 1963: Sending keys to disabled element should throw Element Not interactable error [[Pri-2]]
Resolved issue 2679: Timeout value handling is not spec compliant [[Pri-2]]
Resolved issue 2002: Add Cookie is not spec compliant [[Pri-2]]
Resolved issue 2749: Update Switch To Frame error checks to match latest W3C spec [[Pri-3]]
Resolved issue 2716: Clearing Text Boxes [[Pri-3]]
Resolved issue 2714: ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:15756. Could not start driver. [[Pri-3]]
Resolved issue 2722: Execute Script does not correctly convert document.all into JSON format [[Pri-3]]
Resolved issue 2681: ChromeDriver doesn't differentiate "no such element" and "stale element reference" [[Pri-3]]
```

I also convinced them to add a command line flag to get the minimum Chrome version, so our process is a little easier.