### PR TITLE
Add flag to skip binary download/install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ matrix:
         - ls -la
       script:
         - npm install
+        - npm run chromedriver
         - ls -la
         - ls -la chromedriver/*
     - os: windows
       install:
         - ls -la
       script:
-        - npm install --chromedriver_version='2.31'
+        - npm install
+        - npm run chromedriver --chromedriver_version='2.31'
         - ls -la
         - ls -la chromedriver/*
     - os: osx

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Because of the oddities of `npm`'s lifecycle hooks, installing locally the first
 
 The solution, however, is simple. Simple run `gulp transpile` and then `npm install`. The former will build the project and the latter will simply install the binary.
 
+## Skipping binary installation
+
+If, for some reason, you want to install without installing the Chromedriver
+binary, either set the `APPIUM_SKIP_CHROMEDRIVER_INSTALL` environment variable,
+or pass the `--chromedriver-skip-install` flag while running `npm install`.
+
 
 ## Usage
 

--- a/install-npm.js
+++ b/install-npm.js
@@ -4,6 +4,8 @@
 
 const fs = require('fs');
 const path = require('path');
+const log = require('fancy-log');
+const _ = require('lodash');
 
 
 function waitForDeps (cb) {
@@ -32,7 +34,14 @@ function waitForDeps (cb) {
   check();
 }
 
-if (require.main === module) {
+function main () {
+  // check if we should skip install
+  if (!_.isEmpty(process.env.APPIUM_SKIP_CHROMEDRIVER_INSTALL) || !_.isEmpty(process.env.npm_config_chromedriver_skip_install)) {
+    log.warn(`'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable set, or '--chromedriver-skip-install' flag set.`);
+    log.warn(`Skipping Chromedriver installation. Android web/hybrid testing will not be possible`);
+    return;
+  }
+
   // check if cur dir exists
   const installScript = path.resolve(__dirname, 'build', 'lib', 'install.js');
   waitForDeps(function wait (err) {
@@ -52,4 +61,8 @@ if (require.main === module) {
       });
     });
   });
+}
+
+if (require.main === module) {
+  main();
 }

--- a/package.json
+++ b/package.json
@@ -63,11 +63,10 @@
     "chromedriver_all": "node install-npm.js --all",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
-    "lint": "gulp eslint",
-    "lint:fix": "gulp eslint --fix"
+    "lint": "gulp lint",
+    "lint:fix": "gulp lint --fix"
   },
   "devDependencies": {
-    "ajv": "^6.5.3",
     "appium-gulp-plugins": "^3.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   ],
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublishOnly": "gulp prepublish",
-    "postinstall": "gulp clean && gulp transpile && node install-npm.js",
+    "prepare": "gulp prepublish",
+    "postinstall": "node install-npm.js",
     "test": "gulp once",
     "watch": "gulp watch",
     "build": "gulp transpile",


### PR DESCRIPTION
It is sometimes advantageous to be able to install Appium without installing the Chromedriver 
binary. This PR adds the option to do so, either with
```
APPIUM_SKIP_CHROMEDRIVER_INSTALL=1 npm install -g appium
```
or 
```
npm install -g appium --chromedriver-skip-install
```