### PR TITLE
 Add version 74.0.3729.6

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -20,7 +20,6 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
-  '75.0.3770.8': '75.0.3770',
   '74.0.3729.6': '74.0.3729',
   '73.0.3683.68': '70.0.3538',
   '2.46': '71.0.3578',
@@ -490,7 +489,7 @@ class Chromedriver extends events.EventEmitter {
     // retry session start 4 times, sometimes this fails due to adb
     await retryInterval(4, 200, async () => {
       try {
-        let res = await this.jwproxy.command('/session', 'POST', {desiredCapabilities: this.capabilities});
+        const res = await this.jwproxy.command('/session', 'POST', {desiredCapabilities: this.capabilities});
         // ChromeDriver can return a positive status despite failing
         if (res.status) {
           throw new Error(res.value.message);

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -20,6 +20,8 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '75.0.3770.8': '75.0.3770',
+  '74.0.3729.6': '74.0.3729',
   '73.0.3683.68': '70.0.3538',
   '2.46': '71.0.3578',
   '2.45': '70.0.0',


### PR DESCRIPTION
[Notes](https://chromedriver.storage.googleapis.com/74.0.3729.6/notes.txt):
```
----------ChromeDriver v74.0.3729.6 (2019-03-14)----------
Supports Chrome v74
Resolved issue 2799: Recent change to WebDriver Tests causes ChromeDriver to fail W3C Tests [[Pri-]]
Resolved issue 2798: GET /sessions is not working if at least one of the sessions is in W3C mode [[Pri-3]]
Resolved issue 2783: Improper UTF-8 encoding for CSS child selectors (driver.page_source) [[Pri-]]
Resolved issue 2782: ChromeDriver can't connect to Chrome when /dev/shm is not available on Linux [[Pri-2]]
Resolved issue 2773: Raise a standard exception when element is overlay by another element [[Pri-2]]
Resolved issue 2768: 2.46 produces unexpected debug.log file if verbose logging is enabled [[Pri-1]]
Resolved issue 2749: Update Switch To Frame error checks to match latest W3C spec [[Pri-3]]
Resolved issue  755: /session/:sessionId/doubleclick only generates one set of mousedown/mouseup/click events [[Pri-2]]
Resolved issue  427: Clicking div with SVG image causes "cannot read property 'length' of undefined" error. [[Pri-2]]
```

Version `75.0.3770.8` only works on the beta Chrome 75, so removed.