### PR TITLE
The client implementation for Chromedriver storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 import { default as chromedriver } from './lib/chromedriver';
+import ChromedriverStorageClient from './lib/storage-client';
 
+export { ChromedriverStorageClient };
 export default chromedriver;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -351,7 +351,7 @@ class Chromedriver extends events.EventEmitter {
           }
         }
         log.errorAndThrow(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
-          `See ${CHROMEDRIVER_TUTORIAL} for more details ${autodownloadMsg}`);
+          `See ${CHROMEDRIVER_TUTORIAL} for more details` + autodownloadMsg);
       }
 
       const binPath = workingCds[0].executable;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -12,6 +12,7 @@ import semver from 'semver';
 import _ from 'lodash';
 import path from 'path';
 import compareVersions from 'compare-versions';
+import ChromedriverStorageClient from './storage-client';
 
 
 const log = logger.getLogger('Chromedriver');
@@ -108,6 +109,7 @@ class Chromedriver extends events.EventEmitter {
       verbose,
       logPath,
       disableBuildCheck,
+      isAutodownloadEnabled = false,
     } = args;
 
     this.proxyHost = host;
@@ -126,6 +128,9 @@ class Chromedriver extends events.EventEmitter {
     this.verbose = verbose;
     this.logPath = logPath;
     this.disableBuildCheck = !!disableBuildCheck;
+    this.storageClient = isAutodownloadEnabled
+      ? new ChromedriverStorageClient({ chromedriverDir: this.executableDir })
+      : null;
   }
 
   async getMapping () {
@@ -254,53 +259,109 @@ class Chromedriver extends events.EventEmitter {
     }
 
     const mapping = await this.getMapping();
-    const cds = await this.getChromedrivers(mapping);
+    let didStorageSync = false;
+    const syncChromedrivers = async (chromeVersion) => {
+      didStorageSync = true;
+      const retrievedMapping = await this.storageClient.retrieveMapping();
+      log.debug('Got chromedrivers mapping from the storage: ' +
+        JSON.stringify(retrievedMapping, null, 2));
+      const driverKeys = await this.storageClient.syncDrivers({
+        minBrowserVersion: chromeVersion.major,
+      });
+      if (_.isEmpty(driverKeys)) {
+        return false;
+      }
+      const synchronizedDriversMapping = driverKeys.reduce((acc, x) => {
+        const {version, minBrowserVersion} = retrievedMapping[x];
+        acc[version] = minBrowserVersion;
+        return acc;
+      }, {});
+      Object.assign(mapping, synchronizedDriversMapping);
+      let shouldUpdateGlobalMapping = true;
+      if (await fs.exists(this.mappingPath)) {
+        try {
+          await fs.writeFile(this.mappingPath, JSON.stringify(mapping, null, 2), 'utf8');
+          shouldUpdateGlobalMapping = false;
+        } catch (e) {
+          log.warn(`Cannot store the updated chromedrivers mapping into '${this.mappingPath}'. ` +
+            `This may reduce the performance of further executions. Original error: ${e.message}`);
+        }
+      }
+      if (shouldUpdateGlobalMapping) {
+        Object.assign(CHROMEDRIVER_CHROME_MAPPING, mapping);
+      }
+      return true;
+    };
 
-    if (this.disableBuildCheck) {
-      const cd = cds[0];
-      log.warn(`Chrome build check disabled. Using most recent Chromedriver version (${cd.version}, at '${cd.executable}')`);
-      log.warn(`If this is wrong, set 'chromedriverDisableBuildCheck' capability to 'false'`);
-      return cd.executable;
-    }
+    do {
+      const cds = await this.getChromedrivers(mapping);
 
-    const chromeVersion = await this.getChromeVersion();
+      if (this.disableBuildCheck) {
+        const {version, executable} = cds[0];
+        log.warn(`Chrome build check disabled. Using most recent Chromedriver version (${version}, at '${executable}')`);
+        log.warn(`If this is wrong, set 'chromedriverDisableBuildCheck' capability to 'false'`);
+        return executable;
+      }
 
-    if (!chromeVersion) {
-      // unable to get the chrome version
-      let cd = cds[0];
-      log.warn(`Unable to discover Chrome version. Using Chromedriver ${cd.version} at '${cd.executable}'`);
-      return cd.executable;
-    }
+      const chromeVersion = await this.getChromeVersion();
+      if (!chromeVersion) {
+        // unable to get the chrome version
+        const {version, executable} = cds[0];
+        log.warn(`Unable to discover Chrome version. Using Chromedriver ${version} at '${executable}'`);
+        return executable;
+      }
 
-    log.debug(`Found Chrome bundle '${this.bundleId}' version '${chromeVersion}'`);
+      log.debug(`Found Chrome bundle '${this.bundleId}' version '${chromeVersion}'`);
 
-    if (semver.gt(chromeVersion, _.values(mapping)[0]) &&
-        !_.isUndefined(cds[0]) && _.isUndefined(cds[0].minChromeVersion)) {
-      // this is a chrome above the latest version we know about,
-      // and we have a chromedriver that is beyond what we know,
-      // so use the most recent chromedriver that we found
-      let cd = cds[0];
-      log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'.\n` +
-               `Using Chromedriver version '${cd.version}', which has not been tested with Appium.`);
-      return cd.executable;
-    }
+      const autodownloadMsg = this.storageClient && didStorageSync
+        ? ''
+        : '. You could also try to enable automated chromedrivers download server feature';
+      if (semver.gt(chromeVersion, _.values(mapping)[0]) && cds[0] && !cds[0].minChromeVersion) {
+        if (this.storageClient && !didStorageSync) {
+          try {
+            if (await syncChromedrivers(chromeVersion)) {
+              continue;
+            }
+          } catch (e) {
+            log.warn(e.stack);
+          }
+        }
+        // this is a chrome above the latest version we know about,
+        // and we have a chromedriver that is beyond what we know,
+        // so use the most recent chromedriver that we found
+        const {version, executable} = cds[0];
+        log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'.\n` +
+          `Using Chromedriver version '${version}', which has not been tested with Appium` +
+          autodownloadMsg);
+        return executable;
+      }
 
-    const workingCds = cds.filter((cd) => {
-      return !_.isUndefined(cd.minChromeVersion) && semver.gte(chromeVersion, cd.minChromeVersion);
-    });
+      const workingCds = cds.filter((cd) => {
+        const versionObj = semver.coerce(cd.minChromeVersion);
+        return versionObj && chromeVersion.major === versionObj.major;
+      });
+      if (_.isEmpty(workingCds)) {
+        if (this.storageClient && !didStorageSync) {
+          try {
+            if (await syncChromedrivers(chromeVersion)) {
+              continue;
+            }
+          } catch (e) {
+            log.warn(e.stack);
+          }
+        }
+        log.errorAndThrow(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
+          `See ${CHROMEDRIVER_TUTORIAL} for more details ${autodownloadMsg}`);
+      }
 
-    if (_.isEmpty(workingCds)) {
-      log.errorAndThrow(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
-                        `See ${CHROMEDRIVER_TUTORIAL} for more details.`);
-    }
-
-    const binPath = workingCds[0].executable;
-    log.debug(`Found ${workingCds.length} Chromedriver executable${workingCds.length === 1 ? '' : 's'} ` +
-              `capable of automating Chrome '${chromeVersion}'.\n` +
-              `Choosing the most recent, '${binPath}'.`);
-    log.debug('If a specific version is required, specify it with the `chromedriverExecutable`' +
-              'desired capability.');
-    return binPath;
+      const binPath = workingCds[0].executable;
+      log.debug(`Found ${workingCds.length} Chromedriver executable${workingCds.length === 1 ? '' : 's'} ` +
+        `capable of automating Chrome '${chromeVersion}'.\nChoosing the most recent, '${binPath}'.`);
+      log.debug('If a specific version is required, specify it with the `chromedriverExecutable`' +
+        'desired capability.');
+      return binPath;
+    // eslint-disable-next-line no-constant-condition
+    } while (true);
   }
 
   async initChromedriverPath () {

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -10,7 +10,7 @@ import { system, fs, logger, tempDir, zip, util } from 'appium-support';
 
 
 const STORAGE_URL = 'https://chromedriver.storage.googleapis.com';
-const TIMEOUT = 15000;
+const TIMEOUT_MS = 15000;
 const MAX_PARALLEL_DOWNLOADS = 5;
 
 const log = logger.getLogger('ChromedriverStorageClient');
@@ -85,7 +85,7 @@ class ChromedriverStorageClient {
   constructor (args = {}) {
     const {
       chromedriverDir = getChromedriverDir(),
-      timeout = TIMEOUT,
+      timeout = TIMEOUT_MS,
     } = args;
     this.chromedriverDir = chromedriverDir;
     this.timeout = timeout;

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -1,0 +1,339 @@
+import { getChromedriverDir } from './utils';
+import _ from 'lodash';
+import requestPromise from 'request-promise';
+import request from 'request';
+import xpath from 'xpath';
+import { DOMParser } from 'xmldom';
+import B from 'bluebird';
+import path from 'path';
+import { system, fs, logger, tempDir, zip, util } from 'appium-support';
+
+
+const STORAGE_URL = 'https://chromedriver.storage.googleapis.com';
+const TIMEOUT = 15000;
+const MAX_PARALLEL_DOWNLOADS = 5;
+
+const log = logger.getLogger('ChromedriverStorageClient');
+
+async function walkDir (dir) {
+  const result = [];
+  for (const name of await fs.readdir(dir)) {
+    const currentPath = path.join(dir, name);
+    result.push(currentPath);
+    if ((await fs.stat(currentPath)).isDirectory()) {
+      result.push(...(await walkDir(currentPath)));
+    }
+  }
+  return result;
+}
+
+async function getOsInfo () {
+  let name = 'linux';
+  if (system.isWindows()) {
+    name = 'win';
+  } else if (system.isMac()) {
+    name = 'mac';
+  }
+  return {
+    name,
+    arch: await system.arch(),
+  };
+}
+
+async function isCrcOk (src, checksum) {
+  const md5 = await fs.hash(src, 'md5');
+  return _.toLower(md5) === _.toLower(checksum);
+}
+
+function findChildNode (parent, childName = null, text = null) {
+  if (!childName && !text) {
+    return null;
+  }
+  if (!parent.hasChildNodes()) {
+    return null;
+  }
+
+  for (let childNodeIdx = 0; childNodeIdx < parent.childNodes.length; childNodeIdx++) {
+    const childNode = parent.childNodes[childNodeIdx];
+    if (childName && !text && childName === childNode.localName) {
+      return childNode;
+    }
+    if (text) {
+      const childText = extractNodeText(childNode);
+      if (!childText) {
+        continue;
+      }
+      if (childName && childName === childNode.localName && text === childText) {
+        return childNode;
+      }
+      if (!childName && text === childText) {
+        return childNode;
+      }
+    }
+  }
+  return null;
+}
+
+function extractNodeText (node) {
+  return (!node || !node.firstChild || !util.hasValue(node.firstChild.nodeValue))
+    ? null
+    : node.firstChild.nodeValue;
+}
+
+
+class ChromedriverStorageClient {
+  constructor (args = {}) {
+    const {
+      chromedriverDir = getChromedriverDir(),
+      timeout = TIMEOUT,
+    } = args;
+    this.chromedriverDir = chromedriverDir;
+    this.timeout = timeout;
+    this.mapping = {};
+  }
+
+  parseNotes (content) {
+    const result = {};
+    const versionMatch = /^\s*[-]+ChromeDriver[\D]+([\d.]+)/im.exec(content);
+    if (versionMatch) {
+      result.version = versionMatch[1];
+    }
+    const minBrowserVersionMatch = /^\s*Supports Chrome[\D]+(\d+)/im.exec(content);
+    if (minBrowserVersionMatch) {
+      result.minBrowserVersion = minBrowserVersionMatch[1];
+    }
+    return result;
+  }
+
+  async retrieveAdditionalDriverInfo (driverKey, notesUrl, infoDict) {
+    const response = await requestPromise({
+      url: notesUrl,
+      method: 'GET',
+      headers: {
+        'user-agent': 'appium',
+        accept: '*/*',
+      },
+      resolveWithFullResponse: true,
+      timeout: this.timeout,
+    });
+    const { minBrowserVersion } = this.parseNotes(response.body);
+    if (!minBrowserVersion) {
+      log.debug(`The driver '${driverKey}' does not contain valid notes. Skipping it`);
+      return;
+    }
+    infoDict.minBrowserVersion = minBrowserVersion;
+  }
+
+  async parseStorageXml (doc, parseNotes = true) {
+    const driverNodes = xpath.select(`//*[local-name(.)='Contents']`, doc);
+    log.debug(`Parsed ${driverNodes.length} entries from storage XML`);
+    if (_.isEmpty(driverNodes)) {
+      return;
+    }
+
+    const fibers = [];
+    for (const driverNode of driverNodes) {
+      const key = extractNodeText(findChildNode(driverNode, 'Key'));
+      if (!_.includes(key, '/chromedriver_')) {
+        continue;
+      }
+
+      log.debug(`Processing chromedriver entry '${key}'`);
+      const etag = extractNodeText(findChildNode(driverNode, 'ETag'));
+      if (!etag) {
+        log.debug(`The entry '${key}' does not contain the checksum. Skipping it`);
+        continue;
+      }
+
+      const cdInfo = {
+        url: `${STORAGE_URL}/${key}`,
+        etag: _.trim(etag, '"'),
+        version: _.first(key.split('/')),
+      };
+      this.mapping[key] = cdInfo;
+      log.debug(`Added a new entry to the storage mapping: ${JSON.stringify(cdInfo)}`);
+
+      const notesPath = `${cdInfo.version}/notes.txt`;
+      const isNotesPresent = !!driverNodes
+        .reduce((acc, node) => acc || findChildNode(node, 'Key', notesPath), false);
+      if (!isNotesPresent) {
+        cdInfo.minBrowserVersion = null;
+        if (parseNotes) {
+          log.info(`The entry '${key}' does not contain any notes. Skipping it`);
+        }
+        continue;
+      } else if (!parseNotes) {
+        continue;
+      }
+
+      fibers.push(this.retrieveAdditionalDriverInfo(key, `${STORAGE_URL}/${notesPath}`, cdInfo));
+      if (fibers.length % MAX_PARALLEL_DOWNLOADS === 0) {
+        await B.all(fibers);
+      }
+    }
+    await B.all(fibers);
+    log.info(`The total count of entries in the mapping: ${_.size(this.mapping)}`);
+  }
+
+  async retrieveMapping (parseNotes = true) {
+    const response = await requestPromise({
+      url: STORAGE_URL,
+      method: 'GET',
+      headers: {
+        'user-agent': 'appium',
+        accept: 'application/xml, */*',
+      },
+      resolveWithFullResponse: true,
+      timeout: this.timeout,
+    });
+    const doc = new DOMParser().parseFromString(response.body);
+    await this.parseStorageXml(doc, parseNotes);
+    return _.cloneDeep(this.mapping);
+  }
+
+  async unzipDriver (src, dst) {
+    const tmpRoot = await tempDir.openDir();
+    try {
+      await zip.extractAllTo(src, tmpRoot);
+      const allExtractedItems = await walkDir(tmpRoot);
+      const chromedriverPath = allExtractedItems
+        .find((p) => path.parse(p).name === 'chromedriver');
+      if (!chromedriverPath) {
+        throw new Error('The archive was unzipped properly, but we could not find any chromedriver executable');
+      }
+      log.debug(`Moving the extracted '${path.basename(chromedriverPath)}' to '${dst}'`);
+      await fs.mv(chromedriverPath, dst, {
+        mkdirp: true
+      });
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+  }
+
+  selectMatchingDrivers (osInfo, opts = {}) {
+    const {
+      minBrowserVersion,
+      versions = [],
+    } = opts;
+    let driversToSync = _.keys(this.mapping);
+
+    if (!_.isEmpty(versions)) {
+      // Handle only selected versions if requested
+      log.debug(`Selecting chromedrivers whose versions match to ${versions}`);
+      driversToSync = driversToSync
+        .filter((x) => versions.includes(`${this.mapping[x].version}`));
+      log.debug(`Got ${driversToSync.length} item${driversToSync.length === 1 ? '' : 's'}`);
+    }
+
+    if (minBrowserVersion) {
+      // Only select drivers, where the given browser version is set as the minimal one
+      log.debug(`Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersion}`);
+      driversToSync = driversToSync.reduce(
+        (acc, x) => this.mapping[x].minBrowserVersion === `${minBrowserVersion}` ? [...acc, x] : acc, []);
+      log.debug(`Got ${driversToSync.length} item${driversToSync.length === 1 ? '' : 's'}`);
+    }
+
+    // Filter out driver for unsupported system architectures
+    let {name, arch} = osInfo;
+    if (arch === '64' && !driversToSync.some((x) => x.includes(`_${name}64`))) {
+      // Fall back to x86 build if x64 one is not available for the given OS
+      arch = '32';
+    }
+    log.debug(`Selecting chromedrivers whose platform matches to ${name}${arch}`);
+    driversToSync = driversToSync.filter((x) => x.includes(`_${name}${arch}`));
+    log.debug(`Got ${driversToSync.length} item${driversToSync.length === 1 ? '' : 's'}`);
+
+    return driversToSync;
+  }
+
+  async retrieveDriver (index, driverKey, archivesRoot, isStrict = false) {
+    const { url, etag, version } = this.mapping[driverKey];
+    const archivePath = path.resolve(archivesRoot, `${index}.zip`);
+    log.debug(`Retrieving '${url}' to '${archivePath}'`);
+    try {
+      await new B((resolve, reject) => {
+        request(url)
+          .on('error', reject)
+          .on('response', (res) => {
+            // handle responses that fail, like 404s
+            if (res.statusCode >= 400) {
+              return reject(`Error downloading chromedriver at ${url}: ${res.statusCode}`);
+            }
+          })
+          .pipe(fs.createWriteStream(archivePath))
+          .on('close', resolve);
+      });
+    } catch (e) {
+      const msg = `Cannot download chromedriver archive. Original error: ${e.message}`;
+      if (isStrict) {
+        throw new Error(msg);
+      }
+      log.error(msg);
+      return false;
+    }
+    if (!await isCrcOk(archivePath, etag)) {
+      const msg = `The checksum for the downloaded chromedriver '${driverKey}' did not match`;
+      if (isStrict) {
+        throw new Error(msg);
+      }
+      log.error(msg);
+      return false;
+    }
+    const fileName = `${path.parse(url).name}_v${version}` +
+      (system.isWindows() ? '.exe' : '');
+    const targetPath = path.resolve(this.chromedriverDir, fileName);
+    try {
+      await this.unzipDriver(archivePath, targetPath);
+    } catch (e) {
+      if (isStrict) {
+        throw e;
+      }
+      log.error(e.message);
+      return false;
+    }
+    return true;
+  }
+
+  async syncDrivers (opts = {}) {
+    if (_.isEmpty(this.mapping)) {
+      await this.retrieveMapping(!!opts.minBrowserVersion);
+    }
+    if (_.isEmpty(this.mapping)) {
+      throw new Error('Cannot retrieve chromedrivers mapping from Google storage');
+    }
+
+    const driversToSync = this.selectMatchingDrivers(await getOsInfo(), opts);
+    if (_.isEmpty(driversToSync)) {
+      log.debug(`There are no drivers to sync. Exiting`);
+      return;
+    }
+    log.debug(`Got ${driversToSync.length} driver(s) to sync: ${driversToSync}`);
+
+    let synchronizedDriversCount = 0;
+    const fibers = [];
+    const archivesRoot = await tempDir.openDir();
+    try {
+      for (const [idx, driverKey] of driversToSync.entries()) {
+        fibers.push((async () => {
+          if (await this.retrieveDriver(idx, driverKey, archivesRoot, !_.isEmpty(opts))) {
+            synchronizedDriversCount++;
+          }
+        })());
+
+        if (fibers.length % MAX_PARALLEL_DOWNLOADS === 0) {
+          await B.all(fibers);
+        }
+      }
+      await B.all(fibers);
+    } finally {
+      await fs.rimraf(archivesRoot);
+    }
+    if (synchronizedDriversCount) {
+      log.info(`Successfully synchronized ${synchronizedDriversCount} chromedriver${synchronizedDriversCount === 1 ? '' : 's'}`);
+    } else {
+      log.info(`No chromedrivers were synchronized`);
+    }
+  }
+}
+
+export default ChromedriverStorageClient;

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -124,7 +124,7 @@ class ChromedriverStorageClient {
     infoDict.minBrowserVersion = minBrowserVersion;
   }
 
-  async parseStorageXml (doc, parseNotes = true) {
+  async parseStorageXml (doc, shouldParseNotes = true) {
     const driverNodes = xpath.select(`//*[local-name(.)='Contents']`, doc);
     log.debug(`Parsed ${driverNodes.length} entries from storage XML`);
     if (_.isEmpty(driverNodes)) {
@@ -158,11 +158,11 @@ class ChromedriverStorageClient {
         .reduce((acc, node) => acc || findChildNode(node, 'Key', notesPath), false);
       if (!isNotesPresent) {
         cdInfo.minBrowserVersion = null;
-        if (parseNotes) {
+        if (shouldParseNotes) {
           log.info(`The entry '${key}' does not contain any notes. Skipping it`);
         }
         continue;
-      } else if (!parseNotes) {
+      } else if (!shouldParseNotes) {
         continue;
       }
 
@@ -175,7 +175,7 @@ class ChromedriverStorageClient {
     log.info(`The total count of entries in the mapping: ${_.size(this.mapping)}`);
   }
 
-  async retrieveMapping (parseNotes = true) {
+  async retrieveMapping (shouldParseNotes = true) {
     const response = await requestPromise({
       url: STORAGE_URL,
       method: 'GET',
@@ -187,7 +187,7 @@ class ChromedriverStorageClient {
       timeout: this.timeout,
     });
     const doc = new DOMParser().parseFromString(response.body);
-    await this.parseStorageXml(doc, parseNotes);
+    await this.parseStorageXml(doc, shouldParseNotes);
     return _.cloneDeep(this.mapping);
   }
 

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -92,6 +92,21 @@ class ChromedriverStorageClient {
     this.mapping = {};
   }
 
+  /**
+   * @typedef {Object} AdditionalDriverDetails
+   * @property {?string} version - Chromedriver version
+   * or `null` if it cannot be found
+   * @property {?string} minBrowserVersion - The minimum browser version
+   * supported by chromedriver or `null` if it cannot be found
+   */
+
+  /**
+   * Gets additional chromedriver details from chromedriver
+   * release notes
+   *
+   * @param {string} content - Release notes of the corresponding chromedriver
+   * @returns {AdditionalDriverDetails}
+   */
   parseNotes (content) {
     const result = {};
     const versionMatch = /^\s*[-]+ChromeDriver[\D]+([\d.]+)/im.exec(content);
@@ -105,6 +120,16 @@ class ChromedriverStorageClient {
     return result;
   }
 
+  /**
+   * Downloads chromedriver release notes and puts them
+   * into the dictionary argument
+   *
+   * @param {string} driverKey - Driver version plus archive name
+   * @param {string} notesUrl - The URL of chromedriver notes
+   * @param {Object} infoDict - The dictionary containing driver info.
+   * The method call mutates by merging `AdditionalDriverDetails`
+   * @throws {Error} if the release notes cannot be downloaded
+   */
   async retrieveAdditionalDriverInfo (driverKey, notesUrl, infoDict) {
     const response = await requestPromise({
       url: notesUrl,
@@ -124,6 +149,16 @@ class ChromedriverStorageClient {
     infoDict.minBrowserVersion = minBrowserVersion;
   }
 
+  /**
+   * Parses chromedriver storage XML and stores
+   * the parsed results into `this.mapping`
+   *
+   * @param {DOMDocument} doc - The DOM representation
+   * of the chromedriver storage XML
+   * @param {boolean} shouldParseNotes [true] - If set to `true`
+   * then additional drivers information is going to be parsed
+   * and assigned to `this.mapping`
+   */
   async parseStorageXml (doc, shouldParseNotes = true) {
     const driverNodes = xpath.select(`//*[local-name(.)='Contents']`, doc);
     log.debug(`Parsed ${driverNodes.length} entries from storage XML`);
@@ -175,6 +210,29 @@ class ChromedriverStorageClient {
     log.info(`The total count of entries in the mapping: ${_.size(this.mapping)}`);
   }
 
+  /**
+   * @typedef {Object} DriverDetails
+   * @property {string} url - The full url to the corresponding driver in
+   * the remote storage
+   * @property {string} etag - The CRC of the driver archive
+   * @property {string} version - Chromedriver version
+   */
+
+  /**
+   * @typedef {Object} ChromedriversMapping
+   * @property {DriverDetails} - The keys are unique driver identifiers
+   * (version/archive name). The corresponding values have `DriverDetails`
+   * containing chromedriver details
+   */
+
+  /**
+   * Retrieves chromedriver mapping from the storage
+   *
+   * @param {boolean} shouldParseNotes [true] - if set to `true`
+   * then additional chromedrivers info is going to be retrieved and
+   * parsed from release notes
+   * @returns {ChromedriversMapping}
+   */
   async retrieveMapping (shouldParseNotes = true) {
     const response = await requestPromise({
       url: STORAGE_URL,
@@ -191,6 +249,13 @@ class ChromedriverStorageClient {
     return _.cloneDeep(this.mapping);
   }
 
+  /**
+   * Extracts downloaded chromedriver archive
+   * into the given destination
+   *
+   * @param {string} src - The source archive path
+   * @param {string} dst - The destination chromedriver path
+   */
   async unzipDriver (src, dst) {
     const tmpRoot = await tempDir.openDir();
     try {
@@ -210,6 +275,24 @@ class ChromedriverStorageClient {
     }
   }
 
+  /**
+   * @typedef {Object} OSInfo
+   * @property {string} name - The name of the host OS
+   * Can be either `mac`, `windows` or `linux`
+   * @property {string} arch - The architecture of the host OD.
+   * Can be either `32` or `64`
+   */
+
+  /**
+   * Filters `this.mapping` to only select matching
+   * chromedriver entries by operating system information
+   * and/or additional synchronization options (if provided)
+   *
+   * @param {OSInfo} osInfo
+   * @param {?SyncOptions} opts
+   * @returns {Array<String>} The list of filtered chromedriver
+   * entry names (version/archive name)
+   */
   selectMatchingDrivers (osInfo, opts = {}) {
     const {
       minBrowserVersion,
@@ -246,6 +329,21 @@ class ChromedriverStorageClient {
     return driversToSync;
   }
 
+  /**
+   * Retrieves the given chromedriver from the storage
+   * and unpacks it into `this.chromedriverDir` folder
+   *
+   * @param {number} index - The unique driver index
+   * @param {string} driverKey - The driver key in `this.mapping`
+   * @param {string} archivesRoot - The temporary folder path to extract
+   * downloaded archives to
+   * @param {boolean} isStrict [true] - Whether to throw an error (`true`)
+   * or return a boolean result if the driver retrieval process fails
+   * @throws {Error} if there was a failure while retrieving the driver
+   * and `isStrict` is set to `true`
+   * @returns {boolean} if `true` then the chromedriver is successfully
+   * downloaded and extracted
+   */
   async retrieveDriver (index, driverKey, archivesRoot, isStrict = false) {
     const { url, etag, version } = this.mapping[driverKey];
     const archivePath = path.resolve(archivesRoot, `${index}.zip`);
@@ -294,6 +392,24 @@ class ChromedriverStorageClient {
     return true;
   }
 
+  /**
+   * @typedef {Object} SyncOptions
+   * @property {Array<String>} versions - The list of chromedriver
+   * versions to sync. If empty (the default value) then all available
+   * chromedrivers are going to be downloaded and extracted
+   * @property {string|number} minBrowserVersion - The minumum supported
+   * Chrome version that downloaded chromedrivers should support. Can match
+   * multiple drivers.
+   */
+
+  /**
+   * Retrieves chromedrivers from the remote storage
+   * to the local file system
+   *
+   * @param {?SyncOptions} opts
+   * @throws {Error} if there was a problem while retrieving
+   * the drivers
+   */
   async syncDrivers (opts = {}) {
     if (_.isEmpty(this.mapping)) {
       await this.retrieveMapping(!!opts.minBrowserVersion);

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -143,7 +143,8 @@ class ChromedriverStorageClient {
     });
     const { minBrowserVersion } = this.parseNotes(response.body);
     if (!minBrowserVersion) {
-      log.debug(`The driver '${driverKey}' does not contain valid notes. Skipping it`);
+      log.debug(`The driver '${driverKey}' does not contain valid release notes at ${notesUrl}. ` +
+        `Skipping it`);
       return;
     }
     infoDict.minBrowserVersion = minBrowserVersion;
@@ -166,7 +167,7 @@ class ChromedriverStorageClient {
       return;
     }
 
-    const fibers = [];
+    const promises = [];
     for (const driverNode of driverNodes) {
       const key = extractNodeText(findChildNode(driverNode, 'Key'));
       if (!_.includes(key, '/chromedriver_')) {
@@ -186,7 +187,6 @@ class ChromedriverStorageClient {
         version: _.first(key.split('/')),
       };
       this.mapping[key] = cdInfo;
-      log.debug(`Added a new entry to the storage mapping: ${JSON.stringify(cdInfo)}`);
 
       const notesPath = `${cdInfo.version}/notes.txt`;
       const isNotesPresent = !!driverNodes
@@ -201,12 +201,12 @@ class ChromedriverStorageClient {
         continue;
       }
 
-      fibers.push(this.retrieveAdditionalDriverInfo(key, `${STORAGE_URL}/${notesPath}`, cdInfo));
-      if (fibers.length % MAX_PARALLEL_DOWNLOADS === 0) {
-        await B.all(fibers);
+      promises.push(this.retrieveAdditionalDriverInfo(key, `${STORAGE_URL}/${notesPath}`, cdInfo));
+      if (promises.length % MAX_PARALLEL_DOWNLOADS === 0) {
+        await B.all(promises);
       }
     }
-    await B.all(fibers);
+    await B.all(promises);
     log.info(`The total count of entries in the mapping: ${_.size(this.mapping)}`);
   }
 
@@ -409,6 +409,7 @@ class ChromedriverStorageClient {
    * @param {?SyncOptions} opts
    * @throws {Error} if there was a problem while retrieving
    * the drivers
+   * @returns {Array<String} The list of successfully synchronized driver keys
    */
   async syncDrivers (opts = {}) {
     if (_.isEmpty(this.mapping)) {
@@ -421,34 +422,36 @@ class ChromedriverStorageClient {
     const driversToSync = this.selectMatchingDrivers(await getOsInfo(), opts);
     if (_.isEmpty(driversToSync)) {
       log.debug(`There are no drivers to sync. Exiting`);
-      return;
+      return [];
     }
     log.debug(`Got ${driversToSync.length} driver(s) to sync: ${driversToSync}`);
 
-    let synchronizedDriversCount = 0;
-    const fibers = [];
+    const synchronizedDrivers = [];
+    const promises = [];
     const archivesRoot = await tempDir.openDir();
     try {
       for (const [idx, driverKey] of driversToSync.entries()) {
-        fibers.push((async () => {
+        promises.push((async () => {
           if (await this.retrieveDriver(idx, driverKey, archivesRoot, !_.isEmpty(opts))) {
-            synchronizedDriversCount++;
+            synchronizedDrivers.push(driverKey);
           }
         })());
 
-        if (fibers.length % MAX_PARALLEL_DOWNLOADS === 0) {
-          await B.all(fibers);
+        if (promises.length % MAX_PARALLEL_DOWNLOADS === 0) {
+          await B.all(promises);
         }
       }
-      await B.all(fibers);
+      await B.all(promises);
     } finally {
       await fs.rimraf(archivesRoot);
     }
-    if (synchronizedDriversCount) {
-      log.info(`Successfully synchronized ${synchronizedDriversCount} chromedriver${synchronizedDriversCount === 1 ? '' : 's'}`);
+    if (!_.isEmpty(synchronizedDrivers)) {
+      log.info(`Successfully synchronized ${synchronizedDrivers.length} ` +
+        `chromedriver${synchronizedDrivers.length === 1 ? '' : 's'}`);
     } else {
       log.info(`No chromedrivers were synchronized`);
     }
+    return synchronizedDrivers;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
-    "appium-support": "^2.8.0",
+    "appium-support": "^2.29.0",
     "asyncbox": "^2.0.2",
     "bluebird": "^3.5.1",
     "compare-versions": "^3.4.0",
@@ -45,7 +45,9 @@
     "request-promise": "^4.2.2",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.5",
-    "teen_process": "^1.3.1"
+    "teen_process": "^1.3.1",
+    "xmldom": "^0.1.27",
+    "xpath": "^0.0.27"
   },
   "pre-commit": [
     "precommit-msg",

--- a/test/storage-client-e2e-specs.js
+++ b/test/storage-client-e2e-specs.js
@@ -1,0 +1,51 @@
+// transpile:mocha
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import ChromedriverStorageClient from '../lib/storage-client';
+import _ from 'lodash';
+import { fs, tempDir } from 'appium-support';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('ChromedriverStorageClient', function () {
+  this.timeout(2000000);
+
+  it('should retrieve chromedrivers mapping', async function () {
+    const client = new ChromedriverStorageClient();
+    const mapping = await client.retrieveMapping();
+    _.size(mapping).should.be.greaterThan(0);
+  });
+
+  it('should retrieve chromedrivers by versions', async function () {
+    const tmpRoot = await tempDir.openDir();
+    const client = new ChromedriverStorageClient({
+      chromedriverDir: tmpRoot,
+    });
+    try {
+      await client.syncDrivers({
+        versions: ['2.35', '2.34'],
+      });
+      (await fs.readdir(tmpRoot)).length.should.be.eql(2);
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+  });
+
+  it('should retrieve chromedrivers by minBrowserVersion', async function () {
+    const tmpRoot = await tempDir.openDir();
+    const client = new ChromedriverStorageClient({
+      chromedriverDir: tmpRoot,
+    });
+    try {
+      await client.syncDrivers({
+        minBrowserVersion: '60',
+      });
+      (await fs.readdir(tmpRoot)).length.should.be.greaterThan(0);
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+  });
+});

--- a/test/storage-client-e2e-specs.js
+++ b/test/storage-client-e2e-specs.js
@@ -40,9 +40,9 @@ describe('ChromedriverStorageClient', function () {
       chromedriverDir: tmpRoot,
     });
     try {
-      await client.syncDrivers({
+      (await client.syncDrivers({
         minBrowserVersion: '60',
-      }).length.should.be.greaterThan(0);
+      })).length.should.be.greaterThan(0);
       (await fs.readdir(tmpRoot)).length.should.be.greaterThan(0);
     } finally {
       await fs.rimraf(tmpRoot);

--- a/test/storage-client-e2e-specs.js
+++ b/test/storage-client-e2e-specs.js
@@ -25,9 +25,9 @@ describe('ChromedriverStorageClient', function () {
       chromedriverDir: tmpRoot,
     });
     try {
-      await client.syncDrivers({
+      (await client.syncDrivers({
         versions: ['2.35', '2.34'],
-      });
+      })).length.should.be.greaterThan(0);
       (await fs.readdir(tmpRoot)).length.should.be.eql(2);
     } finally {
       await fs.rimraf(tmpRoot);
@@ -42,7 +42,7 @@ describe('ChromedriverStorageClient', function () {
     try {
       await client.syncDrivers({
         minBrowserVersion: '60',
-      });
+      }).length.should.be.greaterThan(0);
       (await fs.readdir(tmpRoot)).length.should.be.greaterThan(0);
     } finally {
       await fs.rimraf(tmpRoot);

--- a/test/storage-client-specs.js
+++ b/test/storage-client-specs.js
@@ -1,0 +1,190 @@
+import ChromedriverStorageClient from '../lib/storage-client';
+import chai from 'chai';
+import _ from 'lodash';
+
+chai.should();
+
+describe('ChromedriverStorageClient', function () {
+  describe('parseNotes', function () {
+    const client = new ChromedriverStorageClient();
+
+    it('should parse valid notes.txt', function () {
+      const info = client.parseNotes(`
+      ----------ChromeDriver v2.16 (2015-06-08)----------
+      Supports Chrome v42-45
+      Resolved issue 1111: Touch Actions fail on WebView [OS-Android, Pri-0]
+      Resolved issue 1118: Tests that use GoBack or GoForward can be flaky [OS-All, Pri-0]
+      Resolved issue 1106: ChromeDriver does not switch back to top frame after navigation events [OS-All, Pri-0]
+      Resolved issue 1102: ChromeDriver does not report ""hasTouchScreen"" when it has a touchscreen [OS-Android, Pri-1]
+
+      ----------ChromeDriver v2.15 (2015-03-26)----------
+      Supports Chrome v40-43
+
+
+      ----------ChromeDriver v2.14 (2015-01-28)----------
+      Supports Chrome v39-42
+      Resolved issue 537: Manually clicking on javascript alert causes chromedriver to return UnexpectedAlertPresentException for all subsequent calls [Pri-3]
+      Resolved issue 1: Implement /sessions command [Pri-3]
+      Resolved issue 975: driver.findElements(By.id("..")) not working correctly when id contains semicolon []
+      Resolved issue 852: Support shadow dom in chromedriver. []
+
+      ----------ChromeDriver v2.13 (2014-12-10)----------
+      Supports Chrome v38-41
+      Resolved issue 997: Chromedriver times out waiting for Tracing.end command to respond [OS-All, Pri-0]
+      Resolved issue 980: GoBack command times out on all platforms [OS-All, Pri-0]
+      Resolved issue 978: ChromeDriver port server fails to reserve port [OS-Linux, Pri-0]
+      Resolved issue 653: Commands goBack and goForward have race condition. [Pri-1]
+      Resolved issue 845: chromedriver fails with "Chrome version must be >= 31.0.1650.59" on Android 4.4.3 webviews [OS-Android, Pri-1]
+      Resolved issue 626: silence chrome logging by default on windows [Pri-1]
+      Resolved issue 973: ChromeDriver fails to close DevTools UI before executing commands [OS-All, Pri-2]
+      `);
+      info.should.eql({
+        version: '2.16',
+        minBrowserVersion: '42',
+      });
+    });
+
+    it('should parse valid notes.txt in newer format', function () {
+      const info = client.parseNotes(`
+      ----------ChromeDriver 76.0.3809.12 (2019-06-07)----------
+      Supports Chrome version 76
+      Resolved issue 1897: Implement Actions API [Pri-1]
+      Resolved issue 2556: Script timeout handling is not spec compliant [Pri-2]
+      Resolved issue 2745: Improve cyclic data structure detection in Execute Script command [Pri-2]
+      Resolved issue 1071: Incorrect serialization in webdriver command response. [Pri-2]
+      Resolved issue 2264: moveToElement() scrolls the top left corner of the element into view [Pri-2]
+      Resolved issue 2852: Do not scroll partially visible elements [Pri-2]
+      Resolved issue 2840: Element Send Keys: Codepoint "U+E001" not supported [Pri-2]
+      Resolved issue 2869: ChromeDriver should return user prompt (or alert) text in unhandled alert error response [Pri-2]
+      Resolved issue 1062: <details> children are always considered displayed [Pri-2]
+      Resolved issue 2555: Script result serialization is not spec compliant [Pri-3]
+      Resolved issue 2892: excludeSwitches option should allow leading dashes in switch names [Pri-3]
+      `);
+      info.should.eql({
+        version: '76.0.3809.12',
+        minBrowserVersion: '76',
+      });
+    });
+
+    it('should parse invalid notes.txt', function () {
+      const info = client.parseNotes('');
+      info.should.eql({});
+    });
+
+    it('should parse semivalid notes.txt', function () {
+      const info = client.parseNotes(`
+      ----------ChromeDriver v2.16 (2015-06-08)----------
+      Resolved issue 1111: Touch Actions fail on WebView [OS-Android, Pri-0]
+      Resolved issue 1118: Tests that use GoBack or GoForward can be flaky [OS-All, Pri-0]
+      Resolved issue 1106: ChromeDriver does not switch back to top frame after navigation events [OS-All, Pri-0]
+      Resolved issue 1102: ChromeDriver does not report ""hasTouchScreen"" when it has a touchscreen [OS-Android, Pri-1]
+      `);
+      info.should.eql({
+        version: '2.16',
+      });
+    });
+  });
+
+  describe('selectMatchingDrivers', function () {
+    const defaultMapping = {
+      '2.0/chromedriver_linux32.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/2.0/chromedriver_linux32.zip',
+        etag: 'c0d96102715c4916b872f91f5bf9b12c',
+        version: '2.0',
+        minBrowserVersion: '20',
+      },
+      '2.0/chromedriver_linux64.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/2.0/chromedriver_linux64.zip',
+        etag: '858ebaf47e13dce7600191ed59974c09',
+        version: '2.0',
+        minBrowserVersion: '20',
+      },
+      '2.0/chromedriver_mac32.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/2.0/chromedriver_mac32.zip',
+        etag: 'efc13db5afc518000d886c2bdcb3a4bc',
+        version: '2.0',
+        minBrowserVersion: '20',
+      },
+      '2.0/chromedriver_win32.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/2.0/chromedriver_win32.zip',
+        etag: 'bbf8fd0fe525a06dda162619cac2b200',
+        version: '2.0',
+        minBrowserVersion: '20',
+      },
+      '76.0.3809.12/chromedriver_linux64.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip',
+        etag: '91e0d276a462019afdabb91333643a5a',
+        version: '76.0.3809.12',
+        minBrowserVersion: '60',
+      },
+      '76.0.3809.12/chromedriver_mac64.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_mac64.zip',
+        etag: '80b9f345478d2a64c62678176de4b6f6',
+        version: '76.0.3809.12',
+        minBrowserVersion: '60',
+      },
+      '76.0.3809.12/chromedriver_win32.zip': {
+        url: 'https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_win32.zip',
+        etag: 'b8d1935aa3f3480c4ceed221af0be9d4',
+        version: '76.0.3809.12',
+        minBrowserVersion: '60',
+      },
+    };
+
+    it('should select appropriate drivers if no options are set', function () {
+      const client = new ChromedriverStorageClient();
+      client.mapping = _.cloneDeep(defaultMapping);
+      const selectedDrivers = client.selectMatchingDrivers({
+        name: 'win',
+        arch: '64',
+      });
+      selectedDrivers.should.eql([
+        '2.0/chromedriver_win32.zip',
+        '76.0.3809.12/chromedriver_win32.zip',
+      ]);
+    });
+
+    it('should select appropriate drivers if versions are set', function () {
+      const client = new ChromedriverStorageClient();
+      client.mapping = _.cloneDeep(defaultMapping);
+      const selectedDrivers = client.selectMatchingDrivers({
+        name: 'linux',
+        arch: '64',
+      }, {
+        versions: ['76.0.3809.12'],
+      });
+      selectedDrivers.should.eql([
+        '76.0.3809.12/chromedriver_linux64.zip',
+      ]);
+    });
+
+    it('should select appropriate drivers if minBrowserVersion is set', function () {
+      const client = new ChromedriverStorageClient();
+      client.mapping = _.cloneDeep(defaultMapping);
+      const selectedDrivers = client.selectMatchingDrivers({
+        name: 'mac',
+        arch: '64',
+      }, {
+        minBrowserVersion: '60',
+      });
+      selectedDrivers.should.eql([
+        '76.0.3809.12/chromedriver_mac64.zip',
+      ]);
+    });
+
+    it('should select appropriate drivers if both minBrowserVersion and versions are set', function () {
+      const client = new ChromedriverStorageClient();
+      client.mapping = _.cloneDeep(defaultMapping);
+      const selectedDrivers = client.selectMatchingDrivers({
+        name: 'mac',
+        arch: '64',
+      }, {
+        versions: ['76.0.3809.12'],
+        minBrowserVersion: '60',
+      });
+      selectedDrivers.should.eql([
+        '76.0.3809.12/chromedriver_mac64.zip',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This is the POC implementation of Chromedriver storage client. The client is able to retrieve all chromedrivers from the storage, which match to the server OS and architecture. It is also possible to limit the drivers selection by particular chromedriver version or by minimum browser version.

I'm still not quite sure on where to invoke chromedrivers synchronisation, but any feedback on the current implementation or feature requests are welcome