### PR TITLE
feat: Add CD 77.0.3865.40

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
     - stage:
       name: Unit tests
       os: linux
-      dist: trusty
+      dist: xenial
       script:
         - npm test
       after_success:
@@ -33,15 +33,14 @@ jobs:
     - stage:
       name: Functional tests
       os: linux
-      dist: trusty
+      dist: xenial
+      services: xvfb
       env:
         - _FORCE_LOGS=1
       addons:
         chrome: stable
       before_script:
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - sleep 3
         - npm run chromedriver
+        - google-chrome --version
       script:
         - npm run e2e-test

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -26,6 +26,7 @@ const MIN_CD_VERSION_WITH_W3C_SUPPORT = 75;
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minumum Chrome version
+  '77.0.3865.40': '77.0.3865.40',
   '76.0.3809.126': '76.0.3809.126',
   '76.0.3809.68': '76.0.3809.68',
   '76.0.3809.25': '76.0.3809.25',


### PR DESCRIPTION
Chromedriver [77.0.3865.40](https://chromedriver.storage.googleapis.com/index.html?path=77.0.3865.40/) was released. Notes:
```
---------ChromeDriver 77.0.3865.40 (2019-08-20)---------
Supports Chrome version 77
Resolved issue 1485: Posting to an iframe blocks commands until returned [Pri-2]
Resolved issue 1616: selenium takesHeapSnapshot get error: org.openqa.selenium.WebDriverException: unknown error: heap snapshot not in JSON format [Pri-3]
Resolved issue 1887: Chromedriver should throw InvalidCookieDomain error while adding cookie with incorrect domain [Pri-]
Resolved issue 1902: Support eager page load strategy [Pri-2]
Resolved issue 1917: Detecting a BASIC auth alert [Pri-3]
Resolved issue 2398: executeAsyncScript should promise-call script, and handle rejected promise [Pri-2]
Resolved issue 2454: Headless mode doesn't save file downloads [Pri-2]
Resolved issue 2621: buffer until timeout when access mp4 url [Pri-2]
Resolved issue 2638: Chrome driver fails to connect to Chrome after the first page load timeout. [Pri-2]
Resolved issue 2659: TimeoutException leaves Chromedriver in a broken state. [Pri-2]
Resolved issue 2690: Implement New Window endpoint [Pri-2]
Resolved issue 2704: Sending Keys to Active Element in a Frame [Pri-2]
Resolved issue 2809: ChromeDriver waits for all child frames to be ready when pageLoadStrategy != none [Pri-2]
Resolved issue 2925: ExecuteScript should promise-handle [Pri-2]
Resolved issue 2940: ElementScreenshot does not crop large elements to the viewport [Pri-2]
Resolved issue 2943: goog:chromeOptions.w3c=false doesn't work for POST request with empty body [Pri-1]
Resolved issue 2944: ActionChains(driver).move_to_element(element).perform() does not anymore work with ChromeDriver 75.0.3770.8 [Pri-2]
Resolved issue 2947: No W3C compliant endpoints for retrieving logs [Pri-2]
Resolved issue 2961: Selenium addExtensions hook fails to parse CRX3 extensions on ChromeDriver [Pri-]
Resolved issue 2964: chromedriver :takeHeapSnapshot command creates snapshot that Chrome DevTools cannot load [Pri-2]
Resolved issue 2975: Webdriver Actions for keys (CONTROL, SHIFT etc..) not working in ChromeDriver 75.0.3770.8 [Pri-2]
Resolved issue 2981: Chromedriver in W3C mode loses mouse state between Actions API calls [Pri-2]
Resolved issue 2990: Update capability name for "loggingPrefs" [Pri-2]
Resolved issue 2992: Error "Cannot call non W3C standard command while in W3C mode" should be recorded in log file [Pri-2]
Resolved issue 2994: Clicking on file upload does not error [Pri-2]
Resolved issue 2995: javascript error: circular reference with ChromeDriver 76.0.3809.25 [Pri-1]
Resolved issue 2998: Chromedriver fails the WPT test test_merge_platformName [Pri-2]
Resolved issue 3007: ChromeDriver 75 - Running Javascript kills driver [Pri-1]
Resolved issue 3011: Perform Actions cannot move pointer to elements in shadow DOM [Pri-2]
Resolved issue 3013: Wrong error thrown if no capabilities nor desired capabilities given [Pri-3]
Resolved issue 3074: Adding function to Object.prototype causes difficulties in JavaScript deserialization [Pri-1]
Resolved issue 3078: ChromeDriver 77.0.3865.19 and later does not work with Android [Pri-1]
Resolved issue 3084: Find Elements not working properly in ChromeDriver 76 when prototype.js 1.6.1 is used [Pri-2]
```

This necessitated adjustments to the Travis config, as Chrome 77 dropped support for Linux Trusty distributions.