### PR TITLE
feat: add CD 78.0.3904.70

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -25,7 +25,8 @@ const DEFAULT_HOST = '127.0.0.1';
 const MIN_CD_VERSION_WITH_W3C_SUPPORT = 75;
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
-  // Chromedriver version: minumum Chrome version
+  // Chromedriver version: minimum Chrome version
+  '78.0.3904.70': '78.0.3904.70',
   '77.0.3865.40': '77.0.3865.40',
   '76.0.3809.126': '76.0.3809.126',
   '76.0.3809.68': '76.0.3809.68',


### PR DESCRIPTION
Add the latest stable version. https://chromedriver.storage.googleapis.com/index.html?path=78.0.3904.70/

```
---------ChromeDriver 78.0.3904.70 (2019-10-21)---------
Supports Chrome version 78
Resolved issue 907: PageLoadTimeout ignored when setting Url [Pri-2]
Resolved issue 2212: Implement Permissions Automation
Resolved issue 3044: Unable to interact with dropdown options using Action in ChromeDriver 76 [Pri-2]
Resolved issue 3047: No matching capabilities found if ChromeOptions() is used [Pri-2]
Resolved issue 3074: Adding function to Object.prototype causes difficulties in JavaScript deserialization [Pri-1]
Resolved issue 3078: ChromeDriver 77.0.3865.19 and later does not work with Android [Pri-1]
Resolved issue 3084: Find Elements not working properly in ChromeDriver 76 when prototype.js 1.6.1 is used [Pri-2]
Resolved issue 3103: ChromeDriver 77.0.3865.40 is returning the result of a Java Script Execution wrong (Coming null instead of complete) [Pri-1]
Resolved issue 3106: Download in headless mode does not honor download.default_directory
Resolved issue 3136: Unable to take a screenshot when page is zoomed out to 25%.
```