### PR TITLE
fix: Do not throw an exception if no chrome drivers are present initially

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -313,6 +313,10 @@ class Chromedriver extends events.EventEmitter {
       const cds = await this.getChromedrivers(mapping);
 
       if (this.disableBuildCheck) {
+        if (_.isEmpty(cds)) {
+          log.errorAndThrow(`There must be at least one Chromedriver executable available for use if ` +
+            `'chromedriverDisableBuildCheck' capability is set to 'true'`);
+        }
         const {version, executable} = cds[0];
         log.warn(`Chrome build check disabled. Using most recent Chromedriver version (${version}, at '${executable}')`);
         log.warn(`If this is wrong, set 'chromedriverDisableBuildCheck' capability to 'false'`);
@@ -322,6 +326,10 @@ class Chromedriver extends events.EventEmitter {
       const chromeVersion = await this.getChromeVersion();
       if (!chromeVersion) {
         // unable to get the chrome version
+        if (_.isEmpty(cds)) {
+          log.errorAndThrow(`There must be at least one Chromedriver executable available for use if ` +
+            `the current Chrome version cannot be determined`);
+        }
         const {version, executable} = cds[0];
         log.warn(`Unable to discover Chrome version. Using Chromedriver ${version} at '${executable}'`);
         return executable;
@@ -332,7 +340,7 @@ class Chromedriver extends events.EventEmitter {
       const autodownloadMsg = this.storageClient && didStorageSync
         ? ''
         : '. You could also try to enable automated chromedrivers download server feature';
-      if (semver.gt(chromeVersion, _.values(mapping)[0]) && cds[0] && !cds[0].minChromeVersion) {
+      if (_.isEmpty(mapping) || semver.gt(chromeVersion, _.values(mapping)[0])) {
         if (this.storageClient && !didStorageSync) {
           try {
             if (await syncChromedrivers(chromeVersion)) {
@@ -344,12 +352,14 @@ class Chromedriver extends events.EventEmitter {
         }
         // this is a chrome above the latest version we know about,
         // and we have a chromedriver that is beyond what we know,
-        // so use the most recent chromedriver that we found
-        const {version, executable} = cds[0];
-        log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'.\n` +
-          `Using Chromedriver version '${version}', which has not been tested with Appium` +
-          autodownloadMsg);
-        return executable;
+        // so usee the most recent chromedriver that we found
+        if (!_.isEmpty(cds) && !cds[0].minChromeVersion) {
+          const {version, executable} = cds[0];
+          log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'.\n` +
+            `Using Chromedriver version '${version}', which has not been tested with Appium` +
+            autodownloadMsg);
+          return executable;
+        }
       }
 
       const workingCds = cds.filter((cd) => {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -227,7 +227,8 @@ class Chromedriver extends events.EventEmitter {
       .filter((cd) => !!cd)
       .sort((a, b) => compareVersions(b.version, a.version));
     if (_.isEmpty(cds)) {
-      log.errorAndThrow(`No Chromedrivers found in '${this.executableDir}'`);
+      log.info(`No Chromedrivers were found in '${this.executableDir}'`);
+      return cds;
     }
     log.debug(`The following Chromedriver executables were found:`);
     for (const cd of cds) {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -355,8 +355,8 @@ class Chromedriver extends events.EventEmitter {
         // so usee the most recent chromedriver that we found
         if (!_.isEmpty(cds) && !cds[0].minChromeVersion) {
           const {version, executable} = cds[0];
-          log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'.\n` +
-            `Using Chromedriver version '${version}', which has not been tested with Appium` +
+          log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'`);
+          log.warn(`Using Chromedriver version '${version}', which has not been tested with Appium` +
             autodownloadMsg);
           return executable;
         }


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/13602