### PR TITLE
feat: add support for android 10 to getChromeVersion

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -240,9 +240,12 @@ class Chromedriver extends events.EventEmitter {
   async getChromeVersion () {
     let chromeVersion;
 
-    // on Android 7+ webviews are backed by the main Chrome, not the system webview
-    if (this.adb && await this.adb.getApiLevel() >= 24) {
-      this.bundleId = CHROME_BUNDLE_ID;
+    // on Android 7-9 webviews are backed by the main Chrome, not the system webview
+    if (this.adb) {
+      const apiLevel = await this.adb.getApiLevel();
+      if (apiLevel >= 24 && apiLevel <= 28) {
+        this.bundleId = CHROME_BUNDLE_ID;
+      }
     }
 
     // try out webviews when no bundle id is sent in


### PR DESCRIPTION
Starting from Android 10, Chrome is no longer used as a WebView provider (unlike on Android 7,8,9). This PR adds support for Chrome version recognition on Android 10.