### PR TITLE
feat: add support for webview browser tester

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -86,6 +86,7 @@ const CHROMEDRIVER_CHROME_MAPPING = {
   '2.0': '27.0.1453',
 };
 const CHROME_BUNDLE_ID = 'com.android.chrome';
+const WEBVIEW_SHELL_BUNDLE_ID = 'org.chromium.webview_shell';
 const WEBVIEW_BUNDLE_IDS = [
   'com.google.android.webview',
   'com.android.webview',
@@ -239,6 +240,18 @@ class Chromedriver extends events.EventEmitter {
 
   async getChromeVersion () {
     let chromeVersion;
+
+    // in case of WebView Browser Tester, simply try to find the underlying webview
+    if (this.bundleId === WEBVIEW_SHELL_BUNDLE_ID) {
+      for (const bundleId of WEBVIEW_BUNDLE_IDS) {
+        chromeVersion = await getChromeVersion(this.adb, bundleId);
+        if (chromeVersion) {
+          this.bundleId = bundleId;
+          return semver.coerce(chromeVersion);
+        }
+      }
+      return null;
+    }
 
     // on Android 7-9 webviews are backed by the main Chrome, not the system webview
     if (this.adb) {


### PR DESCRIPTION
Adds version recognition support for WebView Browser Tester. I.e. makes ChromeDriver version matching and auto-download work when executing Appium tests with `browserName = 'chromium-webview'` capability. 