### PR TITLE
feat: update CD to 79

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -26,6 +26,7 @@ const MIN_CD_VERSION_WITH_W3C_SUPPORT = 75;
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minimum Chrome version
+  '79.0.3945.36': '79.0.3945.36',
   '78.0.3904.70': '78.0.3904.70',
   '77.0.3865.40': '77.0.3865.40',
   '76.0.3809.126': '76.0.3809.126',


### PR DESCRIPTION
https://chromedriver.storage.googleapis.com/index.html?path=79.0.3945.36/
```
---------ChromeDriver 79.0.3945.36 (2019-11-18)---------
Supports Chrome version 79
Resolved issue 2117: Chromedriver locks when an alert()(js) is raised while taking a screenshot [Pri-2]
Resolved issue 2435: Chrome driver reports platform and platformName as XP on Win10 machine [Pri-2]
Resolved issue 2487: "Element is not clickable" when using headless [Pri-]
Resolved issue 3005: WPT test in element_clear "test_not_editable_inputs[hidden]" does not pass [Pri-3]
Resolved issue 3073: Alerts coming from backend response cause ChromeDriver in W3C mode disconnect from browser - unable to interact with Chrome anymore - java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:38699 [Pri-2]
Resolved issue 3133: window.navigator.webdriver is undefined when "enable-automation" is excluded in non-headless mode (should be true) [Pri-2]
Resolved issue 3148: ChromeDriver always ignores certificate errors [Pri-2]
Resolved issue 3205: Chrome driver 78 moveToElement action sometimes moves to wrong y coordinate [Pri-1]
```