### PR TITLE
refactor: do not print error when no cd found

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -398,7 +398,7 @@ class Chromedriver extends events.EventEmitter {
             log.debug(e);
           }
         }
-        log.errorAndThrow(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
+        throw new Error(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
           (!this.storageClient ? `${autodownloadSuggestion}. ` : '') +
           `See ${CHROMEDRIVER_TUTORIAL} for more details`);
       }


### PR DESCRIPTION
This error is currently logged and thrown, then caught and logged, all in this package.
```
[debug] [Chromedriver] Found Chrome bundle 'com.android.chrome' version '69.0.3497'
[Chromedriver] No Chromedriver found that can automate Chrome '69.0.3497'. You could also try to enable automated chromedrivers download server feature. See https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md for more details
[Chromedriver] No Chromedriver found that can automate Chrome '69.0.3497'. You could also try to enable automated chromedrivers download server feature. See https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/web/chromedriver.md for more details
```

So, just throw and rely on the later code to log the error.