### PR TITLE
feat: update to CD 80.0.3987.106

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -26,6 +26,7 @@ const MIN_CD_VERSION_WITH_W3C_SUPPORT = 75;
 const DEFAULT_PORT = 9515;
 const CHROMEDRIVER_CHROME_MAPPING = {
   // Chromedriver version: minimum Chrome version
+  '80.0.3987.106': '80.0.3987.106',
   '79.0.3945.36': '79.0.3945.36',
   '78.0.3904.70': '78.0.3904.70',
   '77.0.3865.40': '77.0.3865.40',


### PR DESCRIPTION
Get the latest stable release (https://chromedriver.storage.googleapis.com/index.html?path=80.0.3987.106/)
```
---------ChromeDriver 80.0.3987.106 (2020-02-13)---------
Supports Chrome version 80
Resolved issue 3155: Load page was aborted when using a proxy (v.77/78). [Pri-2]
Resolved issue 3164: Chromedriver version 77 doesn`t wait for page to fully load before interacting with an element [Pri-2]
Resolved issue 3179: ChromeDriver log should include the port used by the driver [Pri-2]
Resolved issue 3180: Enable SetGeoLocation for w3c mode [Pri-]
Resolved issue 3184: UnexpectedAlertOpen status should always include Alert text [Pri-3]
Resolved issue 3188: Improve message when CRX2 Extension is loaded  [Pri-2]
Resolved issue 3196: ChromeDriver 78 race condition in ExecuteGetPageSource may result in JavascriptException [Pri-2]
Resolved issue 3226: add --ignore-certificate-errors flag when acceptInsecureCerts true [Pri-2]
Resolved issue 3230: Update error message and return status for no such execution context [Pri-2]
Resolved issue 3239: ChromeDriver may block indefinitely while waiting for pending navigation [Pri-2]
Resolved issue 3264: Allow setting SameSite cookie attribute [Pri-]
Resolved issue 3336: WebDriver 80.0.3987.16 can't open Chrome on Linux [Pri-1]
```