### PR TITLE
fix: Avoid a redundant Chromedriver download operation if a matching driver is already present

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -339,8 +339,16 @@ class Chromedriver extends events.EventEmitter {
       }
       log.debug(`Found Chrome bundle '${this.bundleId}' version '${chromeVersion}'`);
 
-      const matchingDrivers = cds.filter(
-        ({minChromeVersion}) => minChromeVersion && (semver.coerce(minChromeVersion))?.major === chromeVersion.major);
+      const matchingDrivers = cds.filter(({minChromeVersion}) => {
+        const minChromeVersionS = minChromeVersion && semver.coerce(minChromeVersion);
+        if (!minChromeVersionS) {
+          return false;
+        }
+
+        return chromeVersion.major > NEW_CD_VERSION_FORMAT_MAJOR_VERSION
+          ? minChromeVersionS.major === chromeVersion.major
+          : semver.gte(chromeVersion, minChromeVersionS);
+      });
       if (_.isEmpty(matchingDrivers)) {
         if (this.storageClient && !didStorageSync) {
           try {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -81,20 +81,23 @@ class Chromedriver extends events.EventEmitter {
     this.desiredProtocol = PROTOCOLS.MJSONWP;
   }
 
-  async getMapping () {
+  async getDriversMapping () {
     let mapping = _.cloneDeep(CHROMEDRIVER_CHROME_MAPPING);
     if (this.mappingPath) {
-      log.debug(`Attempting to use Chromedriver-Chrome mapping from '${this.mappingPath}'`);
+      log.debug(`Attempting to use Chromedriver->Chrome mapping from '${this.mappingPath}'`);
       if (!await fs.exists(this.mappingPath)) {
-        log.warn(`No file found at '${this.mappingPath}'. Using default mapping`);
+        log.warn(`No file found at '${this.mappingPath}'`);
+        log.info('Defaulting to the static Chromedriver->Chrome mapping');
       } else {
         try {
           mapping = JSON.parse(await fs.readFile(this.mappingPath, 'utf8'));
         } catch (err) {
-          log.error(`Error parsing mapping from '${this.mappingPath}': ${err.message}`);
-          log.warn('Using default mapping');
+          log.warn(`Error parsing mapping from '${this.mappingPath}': ${err.message}`);
+          log.info('Defaulting to the static Chromedriver->Chrome mapping');
         }
       }
+    } else {
+      log.debug('Using the static Chromedriver->Chrome mapping');
     }
 
     // make sure that the values for minimum chrome version are semver compliant
@@ -242,12 +245,32 @@ class Chromedriver extends events.EventEmitter {
     return chromeVersion ? semver.coerce(chromeVersion) : null;
   }
 
+  async updateDriversMapping (newMapping) {
+    let shouldUpdateStaticMapping = true;
+    if (await fs.exists(this.mappingPath)) {
+      try {
+        await fs.writeFile(this.mappingPath, JSON.stringify(newMapping, null, 2), 'utf8');
+        shouldUpdateStaticMapping = false;
+      } catch (e) {
+        log.warn(`Cannot store the updated chromedrivers mapping into '${this.mappingPath}'. ` +
+          `This may reduce the performance of further executions. Original error: ${e.message}`);
+      }
+    }
+    if (shouldUpdateStaticMapping) {
+      Object.assign(CHROMEDRIVER_CHROME_MAPPING, newMapping);
+    }
+  }
+
   async getCompatibleChromedriver () {
     if (!this.adb) {
       return await getChromedriverBinaryPath();
     }
 
-    const mapping = await this.getMapping();
+    const mapping = await this.getDriversMapping();
+    if (!_.isEmpty(mapping)) {
+      log.debug(`The most recent known Chrome version: ${_.values(mapping)[0]}`);
+    }
+
     let didStorageSync = false;
     const syncChromedrivers = async (chromeVersion) => {
       didStorageSync = true;
@@ -266,24 +289,31 @@ class Chromedriver extends events.EventEmitter {
         return acc;
       }, {});
       Object.assign(mapping, synchronizedDriversMapping);
-      let shouldUpdateStaticMapping = true;
-      if (await fs.exists(this.mappingPath)) {
-        try {
-          await fs.writeFile(this.mappingPath, JSON.stringify(mapping, null, 2), 'utf8');
-          shouldUpdateStaticMapping = false;
-        } catch (e) {
-          log.warn(`Cannot store the updated chromedrivers mapping into '${this.mappingPath}'. ` +
-            `This may reduce the performance of further executions. Original error: ${e.message}`);
-        }
-      }
-      if (shouldUpdateStaticMapping) {
-        Object.assign(CHROMEDRIVER_CHROME_MAPPING, mapping);
-      }
+      await this.updateDriversMapping(mapping);
       return true;
     };
 
     do {
       const cds = await this.getChromedrivers(mapping);
+
+      const missingVersions = {};
+      for (const {version, minChromeVersion} of cds) {
+        if (!minChromeVersion || mapping[version]) {
+          continue;
+        }
+        const coercedVer = semver.coerce(version);
+        if (!coercedVer || coercedVer.major < NEW_CD_VERSION_FORMAT_MAJOR_VERSION) {
+          continue;
+        }
+
+        missingVersions[version] = minChromeVersion;
+      }
+      if (!_.isEmpty(missingVersions)) {
+        log.info(`Found ${util.pluralize('Chromedriver', _.size(missingVersions), true)}, ` +
+          `which ${_.size(missingVersions) === 1 ? 'is' : 'are'} missing in the list of known versions: ` +
+          JSON.stringify(missingVersions));
+        await this.updateDriversMapping(Object.assign(mapping, missingVersions));
+      }
 
       if (this.disableBuildCheck) {
         if (_.isEmpty(cds)) {
@@ -307,15 +337,11 @@ class Chromedriver extends events.EventEmitter {
         log.warn(`Unable to discover Chrome version. Using Chromedriver ${version} at '${executable}'`);
         return executable;
       }
-
       log.debug(`Found Chrome bundle '${this.bundleId}' version '${chromeVersion}'`);
-      if (!_.isEmpty(mapping)) {
-        log.debug(`The most recent known Chrome version: ${_.values(mapping)[0]}`);
-      }
 
-      const autodownloadSuggestion =
-        'You could also try to enable automated chromedrivers download server feature';
-      if (_.isEmpty(mapping) || chromeVersion.major > (semver.coerce(_.values(mapping)[0]))?.major) {
+      const matchingDrivers = cds.filter(
+        ({minChromeVersion}) => minChromeVersion && (semver.coerce(minChromeVersion))?.major === chromeVersion.major);
+      if (_.isEmpty(matchingDrivers)) {
         if (this.storageClient && !didStorageSync) {
           try {
             if (await syncChromedrivers(chromeVersion)) {
@@ -324,46 +350,18 @@ class Chromedriver extends events.EventEmitter {
           } catch (e) {
             log.warn(`Cannot synchronize local chromedrivers with the remote storage at ${CD_CDN}: ` +
               e.message);
-            log.debug(e);
+            log.debug(e.stack);
           }
         }
-        // this is a chrome above the latest version we know about,
-        // and we have a chromedriver that is beyond what we know,
-        // so usee the most recent chromedriver that we found
-        if (!_.isEmpty(cds) && !cds[0].minChromeVersion) {
-          const {version, executable} = cds[0];
-          log.warn(`No known Chromedriver available to automate Chrome version '${chromeVersion}'`);
-          log.warn(`Using Chromedriver version '${version}', which has not been tested with Appium`);
-          if (!this.storageClient) {
-            log.info(autodownloadSuggestion);
-          }
-          return executable;
-        }
-      }
-
-      const workingCds = cds.filter((cd) => {
-        const versionObj = semver.coerce(cd.minChromeVersion);
-        return versionObj && chromeVersion.major === versionObj.major;
-      });
-      if (_.isEmpty(workingCds)) {
-        if (this.storageClient && !didStorageSync) {
-          try {
-            if (await syncChromedrivers(chromeVersion)) {
-              continue;
-            }
-          } catch (e) {
-            log.warn(`Cannot synchronize local chromedrivers with the remote storage at ${CD_CDN}: ` +
-              e.message);
-            log.debug(e);
-          }
-        }
+        const autodownloadSuggestion =
+          'You could also try to enable automated chromedrivers download server feature';
         throw new Error(`No Chromedriver found that can automate Chrome '${chromeVersion}'. ` +
           (!this.storageClient ? `${autodownloadSuggestion}. ` : '') +
           `See ${CHROMEDRIVER_TUTORIAL} for more details`);
       }
 
-      const binPath = workingCds[0].executable;
-      log.debug(`Found ${util.pluralize('executable', workingCds.length, true)} ` +
+      const binPath = matchingDrivers[0].executable;
+      log.debug(`Found ${util.pluralize('executable', matchingDrivers.length, true)} ` +
         `capable of automating Chrome '${chromeVersion}'.\nChoosing the most recent, '${binPath}'.`);
       log.debug('If a specific version is required, specify it with the `chromedriverExecutable`' +
         'desired capability.');

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -2,6 +2,7 @@ import { Chromedriver } from '../lib/chromedriver';
 import * as utils from '../lib/utils';
 import sinon from 'sinon';
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { fs } from 'appium-support';
 import * as tp from 'teen_process';
 import path from 'path';
@@ -9,6 +10,7 @@ import _ from 'lodash';
 
 
 chai.should();
+chai.use(chaiAsPromised);
 
 describe('chromedriver', function () {
   let sandbox;
@@ -64,9 +66,9 @@ describe('chromedriver', function () {
         binPath.should.eql('/path/to/chromedriver');
       });
 
-      it('should find most recent compatible binary from a number of possibilities', async function () {
+      it('should find most recent compatible binary for older driver versions', async function () {
         sandbox.stub(utils, 'getChromeVersion')
-          .returns('7000.0.3029.42');
+          .returns('70.0.3029.42');
         sandbox.stub(fs, 'glob')
           .returns([
             '/path/to/chromedriver-36',
@@ -80,7 +82,7 @@ describe('chromedriver', function () {
         sandbox.stub(tp, 'exec')
           .onCall(0)
             .returns({
-              stdout: 'ChromeDriver 2.360.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+              stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
             })
           .onCall(1)
             .returns({
@@ -164,9 +166,9 @@ describe('chromedriver', function () {
         }
       });
 
-      it('should find most recent binary from a number of possibilities when chrome is too new', async function () {
+      it('should fail when chrome is too new', async function () {
         sandbox.stub(utils, 'getChromeVersion')
-          .returns('7000.0.0.42');
+          .returns('10000.0.0.42');
         sandbox.stub(fs, 'glob')
           .returns([
             '/path/to/chromedriver-9000',
@@ -192,8 +194,7 @@ describe('chromedriver', function () {
               stdout: 'ChromeDriver 2.35.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
             });
 
-        const binPath = await cd.getCompatibleChromedriver();
-        binPath.should.eql('/path/to/chromedriver-9000');
+        await cd.getCompatibleChromedriver().should.eventually.be.rejected;
       });
 
       it('should search specified directory if provided', async function () {


### PR DESCRIPTION
Fixes https://discuss.appium.io/t/appium-with-enabled-chromedriver-autodownload-download-chrome-driver-each-time-before-create-browser-instance/31484