### PR TITLE
chore: revert base driver 7 once to release a new patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-base-driver": "^7.0.0",
+    "appium-base-driver": "^6.0.0",
     "appium-support": "^2.46.0",
     "asyncbox": "^2.0.2",
     "axios": "^0.19.2",


### PR DESCRIPTION
I want to keep base-driver v6 in 1.18 package, so would like to revert the version once.
After creating a new version, I would like to bump up the version again.