### PR TITLE
chore: Adjust permissions for the driver executable

### DIFF
--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -244,7 +244,7 @@ class ChromedriverStorageClient {
         mkdirp: true
       });
       await fs.chmod(dst, 0o755);
-      log.debug(`The permissions for file '${dst}'  have been changed to 755!`);
+      log.debug(`Permissions of the file '${dst}' have been changed to 755`);
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -338,7 +338,7 @@ class ChromedriverStorageClient {
    * @throws {Error} if there was a failure while retrieving the driver
    * and `isStrict` is set to `true`
    * @returns {boolean} if `true` then the chromedriver is successfully
-   * downloaded and extracted
+   * downloaded and extracted.
    */
   async retrieveDriver (index, driverKey, archivesRoot, isStrict = false) {
     const { url, etag, version } = this.mapping[driverKey];

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -243,7 +243,7 @@ class ChromedriverStorageClient {
       await fs.mv(chromedriverPath, dst, {
         mkdirp: true
       });
-      fs.chmod(dst, 0o755);
+      await fs.chmod(dst, 0o755);
       log.debug(`The permissions for file '${dst}'  have been changed to 755!`);
     } finally {
       await fs.rimraf(tmpRoot);

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -243,12 +243,8 @@ class ChromedriverStorageClient {
       await fs.mv(chromedriverPath, dst, {
         mkdirp: true
       });
-      fs.chmod(dst, 0o755, (err) => {
-        if (err) {
-          throw err;
-        }
-        log.debug(`The permissions for file '${dst}'  have been changed to 755!`);
-      });
+      fs.chmod(dst, 0o755);
+      log.debug(`The permissions for file '${dst}'  have been changed to 755!`);
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -243,6 +243,12 @@ class ChromedriverStorageClient {
       await fs.mv(chromedriverPath, dst, {
         mkdirp: true
       });
+      fs.chmod(dst, 0o755, (err) => {
+        if (err) {
+          throw err;
+        }
+        log.debug(`The permissions for file '${dst}'  have been changed to 755!`);
+      });
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -246,8 +246,6 @@ class ChromedriverStorageClient {
     } finally {
       await fs.rimraf(tmpRoot);
     }
-    await fs.chmod(dst, 0o755);
-    log.debug(`Permissions of the file '${dst}' have been changed to 755`);
   }
 
   /**
@@ -372,6 +370,8 @@ class ChromedriverStorageClient {
     const targetPath = path.resolve(this.chromedriverDir, fileName);
     try {
       await this.unzipDriver(archivePath, targetPath);
+      await fs.chmod(targetPath, 0o755);
+      log.debug(`Permissions of the file '${targetPath}' have been changed to 755`);
     } catch (e) {
       if (isStrict) {
         throw e;

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -243,11 +243,11 @@ class ChromedriverStorageClient {
       await fs.mv(chromedriverPath, dst, {
         mkdirp: true
       });
-      await fs.chmod(dst, 0o755);
-      log.debug(`Permissions of the file '${dst}' have been changed to 755`);
     } finally {
       await fs.rimraf(tmpRoot);
     }
+    await fs.chmod(dst, 0o755);
+    log.debug(`Permissions of the file '${dst}' have been changed to 755`);
   }
 
   /**


### PR DESCRIPTION
Hi folks,

I'm using ```chromedriver_autodownload``` feature and I verify the new chromedriver's version has been downloaded.
But I get this error: 
```
[debug] [ChromedriverStorageClient] Selecting chromedrivers whose minimum supported browser version matches to 86
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient] Got 3 items
Thg 11 12 22:16:07  node[2780457]: [debug] [ChromedriverStorageClient] Will select candidate drivers versioned as '86.0.4240.22'
Thg 11 12 22:16:07  node[2780457]: [debug] [ChromedriverStorageClient] Selecting chromedrivers whose platform matches to linux64
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient] Got 1 item
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient] Got 1 driver to sync: [
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient]   "86.0.4240.22/chromedriver_linux64.zip"
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient] ]
Thg 11 12 22:16:07 node[2780457]: [debug] [ChromedriverStorageClient] Retrieving 'https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip' to '/tmp/20201012-2780457-1gitaoh.lq5y/0.zip'
Thg 11 12 22:16:08 node[2780457]: [debug] [Support] Traversed 1 directory and 1 file in 1ms
Thg 11 12 22:16:08 node[2780457]: [debug] [ChromedriverStorageClient] Moving the extracted 'chromedriver' to '/home/linuxbrew/.linuxbrew/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_linux64_v86.0.4240.22'
Thg 11 12 22:16:08 node[2780457]: [ChromedriverStorageClient] Successfully synchronized 1 chromedriver
Thg 11 12 22:16:08 node[2780457]: [debug] [Chromedriver] Found 2 executables in '/home/linuxbrew/.linuxbrew/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux'
Thg 11 12 22:16:08 node[2780457]: [Chromedriver] Cannot retrieve version number from 'chromedriver_linux64_v86.0.4240.22' Chromedriver binary. Make sure it returns a valid version string in response to '--version' command line argument. Command '/home/linuxbrew/.linuxbrew/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_linux64_v86.0.4240.22 --version' errored out: Error: spawn /home/linuxbrew/.linuxbrew/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_linux64_v86.0.4240.22 EACCES
Thg 11 12 22:16:08 node[2780457]: [Chromedriver]     at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
Thg 11 12 22:16:08 node[2780457]: [Chromedriver]     at onErrorNT (internal/child_process.js:468:16)
Thg 11 12 22:16:08 node[2780457]: [Chromedriver]     at processTicksAndRejections (internal/process/task_queues.js:84:21)
Thg 11 12 22:16:08 node[2780457]: [debug] [Chromedriver] The following Chromedriver executables were found:
Thg 11 12 22:16:08 node[2780457]: [debug] [Chromedriver]     '/home/linuxbrew/.linuxbrew/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/linux/chromedriver_64' (version '84.0.4147.30', minimum Chrome version '84.0.4147')
```
Follow this trace log, I check the file permission of ```chromedriver_linux64_v86.0.4240.22```. It does not have execute permission.
So I create a PR to add execute permission after getting new chromedriver's version.
I'm using Linux OS.
Thank you.