### PR TITLE
fix: bug in chromium-browser handling for Android 7-9

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -216,7 +216,8 @@ class Chromedriver extends events.EventEmitter {
     // on Android 7-9 webviews are backed by the main Chrome, not the system webview
     if (this.adb) {
       const apiLevel = await this.adb.getApiLevel();
-      if (apiLevel >= 24 && apiLevel <= 28) {
+      if (apiLevel >= 24 && apiLevel <= 28 &&
+          [WEBVIEW_SHELL_BUNDLE_ID, ...WEBVIEW_BUNDLE_IDS].includes(this.bundleId)) {
         this.bundleId = CHROME_BUNDLE_ID;
       }
     }


### PR DESCRIPTION
When testing chromium-browser (custom-built chrome) on
Android 7-9, the version of chrome will be used instead
of the chromium-browser, because the bundleId of webview
bundle will be replaced with CHROME_BUNDLE_ID.

This patch fixes the bug by adding a check checking whether
the bundleId is a webview bundle id or not.