### PR TITLE
refactor: Update chromedriver retrieval

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,6 +43,7 @@ jobs:
         fi
     - run: |
         export DISPLAY=:99
+        export _FORCE_LOGS=1
         sudo Xvfb -ac $DISPLAY -screen 0 1280x1024x24 > /dev/null 2>&1 &
         npm run e2e-test
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,13 +34,13 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
     - run: npm run clean
     - run: |
-        export CD_VERSION=$(google-chrome --version | python -c "import sys, re; print(re.search(r'[0-9.]+', sys.stdin.read()).group(0))")
-        echo "$CD_VERSION"
-        export MAJOR_CD_VERSION=$(python -c "print('.'.join('$CD_VERSION'.split('.')[:-1]))")
-        echo "$MAJOR_CD_VERSION"
-        if grep -q "$MAJOR_CD_VERSION" config/mapping.json; then
-          export CHROMEDRIVER_VERSION=$(grep -m 1 -n "$MAJOR_CD_VERSION" config/mapping.json | cut -d' ' -f4 | tr -d ',"')
-          echo "$CHROMEDRIVER_VERSION"
+        export CHROME_VERSION=$(google-chrome --version | python -c "import sys, re; print(re.search(r'[0-9.]+', sys.stdin.read()).group(0))")
+        echo "Version number of the installed Chrome browser: $CHROME_VERSION"
+        export MAJOR_CHROME_VERSION=$(python -c "print('.'.join('$CHROME_VERSION'.split('.')[:-1]))")
+        echo "Major part of the version number: $MAJOR_CHROME_VERSION"
+        if grep -q "$MAJOR_CHROME_VERSION" config/mapping.json; then
+          export CHROMEDRIVER_VERSION=$(grep -m 1 -n "$MAJOR_CHROME_VERSION" config/mapping.json | cut -d' ' -f4 | tr -d ',"')
+          echo "Matching Chromedriver version: $CHROMEDRIVER_VERSION"
         fi
         npm run chromedriver
     - run: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,11 +36,13 @@ jobs:
     - run: |
         export CD_VERSION=$(google-chrome --version | python -c "import sys, re; print(re.search(r'[0-9.]+', sys.stdin.read()).group(0))")
         echo "$CD_VERSION"
-        if grep -q "$CD_VERSION" config/mapping.json; then
-          npm run chromedriver --chromedriver_version=$CD_VERSION
-        else
-          npm run chromedriver
+        export MAJOR_CD_VERSION=$(python -c "print('.'.join('$CD_VERSION'.split('.')[:-1]))")
+        echo "$MAJOR_CD_VERSION"
+        if grep -q "$MAJOR_CD_VERSION" config/mapping.json; then
+          export CHROMEDRIVER_VERSION=$(grep -m 1 -n "$MAJOR_CD_VERSION" config/mapping.json | cut -d' ' -f4 | tr -d ',"')
+          echo "$CHROMEDRIVER_VERSION"
         fi
+        npm run chromedriver
     - run: |
         export DISPLAY=:99
         export _FORCE_LOGS=1

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,135 +1,43 @@
-import _ from 'lodash';
-import path from 'path';
-import { parallel as ll } from 'asyncbox';
-import { system, tempDir, fs, zip, mkdirp, net } from 'appium-support';
+import { fs, mkdirp } from 'appium-support';
+import ChromedriverStorageClient from './storage-client';
 import {
-  CD_CDN, CD_VER, CD_BASE_DIR, getChromedriverBinaryPath,
-  getCurPlatform, getPlatforms, MAC_32_ONLY, retrieveData,
+  CD_CDN, CD_VER, retrieveData, getOsInfo, getChromedriverDir,
 } from './utils';
-import logger from 'fancy-log';
-import semver from 'semver';
 
 
-function log (line) {
-  logger(`[Chromedriver Install] ${line}`);
-}
-
-const CD_PLATS = ['linux', 'win', 'mac'];
-const CD_ARCHS = ['32', '64'];
 const DOWNLOAD_TIMEOUT_MS = 15 * 1000;
+const LATEST_VERSION = 'LATEST';
 
-async function getArchAndPlatform () {
-  let arch = await system.arch();
-  let platform = getCurPlatform();
-  if (platform !== 'linux' && platform !== 'mac') {
-    arch = '32';
-  }
-
-  const cdVer = semver.coerce(CD_VER);
-  if (platform === 'mac' && semver.lt(cdVer, MAC_32_ONLY)) {
-    arch = '32';
-  }
-  return {arch, platform};
-}
-
-function getDownloadUrl (version, platform, arch) {
-  return `${CD_CDN}/${version}/chromedriver_${platform}${arch}.zip`;
-}
-
-function validatePlatform (platform, arch) {
-  if (!_.includes(CD_PLATS, platform)) {
-    throw new Error(`Invalid platform: ${platform}`);
-  }
-  if (!_.includes(CD_ARCHS, arch)) {
-    throw new Error(`Invalid arch: ${arch}`);
-  }
-  if (arch === '64' && platform !== 'linux' && platform !== 'mac') {
-    throw new Error('Only linux has a 64-bit version of Chromedriver');
-  }
-}
-
-async function installForPlatform (version, platform, arch) {
-  if (version === 'LATEST') {
-    version = (await retrieveData(`${CD_CDN}/LATEST_RELEASE`, {
+async function formatCdVersion (ver) {
+  return ver === LATEST_VERSION
+    ? (await retrieveData(`${CD_CDN}/LATEST_RELEASE`, {
       'user-agent': 'appium',
       accept: '*/*',
-    }, { timeout: DOWNLOAD_TIMEOUT_MS })).trim();
+    }, { timeout: DOWNLOAD_TIMEOUT_MS })).trim()
+    : ver;
+}
+
+async function prepareChromedriverDir (platformName) {
+  const chromedriverDir = getChromedriverDir(platformName);
+  if (!await fs.exists(chromedriverDir)) {
+    await mkdirp(chromedriverDir);
   }
-  validatePlatform(platform, arch);
-
-  const url = getDownloadUrl(version, platform, arch);
-
-  log(`Installing Chromedriver version '${version}' for platform '${platform}' and architecture '${arch}'`);
-
-  // set up a temp file to download the chromedriver zipfile to
-  const binarySpec = `chromedriver_${platform}${arch}`;
-  log(`Opening temp file to write '${binarySpec}' to...`);
-  const tempFile = await tempDir.open({
-    prefix: binarySpec,
-    suffix: '.zip'
-  });
-  log(`Opened temp file '${tempFile.path}'`);
-
-  // actually download the zipfile and write it with appropriate perms
-  log(`Downloading ${url} to '${tempFile.path}'`);
-  await net.downloadFile(url, tempFile.path, {timeout: DOWNLOAD_TIMEOUT_MS});
-  await fs.chmod(tempFile.path, 0o0644);
-
-  // extract downloaded zipfile to tempdir
-  const tempUnzipped = path.resolve(path.dirname(tempFile.path), binarySpec);
-  log(`Extracting ${tempFile.path} to ${tempUnzipped}`);
-  await mkdirp(tempUnzipped);
-  await zip.extractAllTo(tempFile.path, tempUnzipped);
-  let extractedBin = path.resolve(tempUnzipped, 'chromedriver');
-  if (platform === 'win') {
-    extractedBin += '.exe';
-  }
-
-  // make build dirs that will hold the chromedriver binary
-  log(`Creating ${path.resolve(CD_BASE_DIR, platform)}...`);
-  await mkdirp(path.resolve(CD_BASE_DIR, platform));
-
-  // copy the extracted binary to the correct build dir
-  const newBin = await getChromedriverBinaryPath(platform, arch);
-  log(`Copying unzipped binary, reading from ${extractedBin}...`);
-  const binContents = await fs.readFile(extractedBin, {encoding: 'binary'});
-  log(`Writing to ${newBin}...`);
-  await fs.writeFile(newBin, binContents, {encoding: 'binary', mode: 0o755});
-  log(`${newBin} successfully put in place`);
+  return chromedriverDir;
 }
 
 async function install () {
-  const {arch, platform} = await getArchAndPlatform();
-  await installForPlatform(CD_VER, platform, arch);
-}
-
-async function conditionalInstall () {
-  const {arch, platform} = await getArchAndPlatform();
-  const binPath = await getChromedriverBinaryPath(platform, arch);
-  if (!await fs.exists(binPath)) {
-    await installForPlatform(CD_VER, platform, arch);
-  } else {
-    log(`No need to install chromedriver, ${binPath} exists`);
-  }
-}
-
-async function installAll () {
-  let downloads = [];
-  for (let [platform, arch] of getPlatforms()) {
-    downloads.push(installForPlatform(CD_VER, platform, arch));
-  }
-  await ll(downloads);
+  const osInfo = await getOsInfo();
+  const client = new ChromedriverStorageClient({
+    chromedriverDir: await prepareChromedriverDir(osInfo.name),
+  });
+  await client.syncDrivers({
+    osInfo,
+    versions: [await formatCdVersion(CD_VER)],
+  });
 }
 
 async function doInstall () {
-  if (_.includes(process.argv, '--all') ||
-      process.env.npm_config_chromedriver_install_all) {
-    await installAll();
-  } else if (_.includes(process.argv, '--conditional')) {
-    await conditionalInstall();
-  } else {
-    await install();
-  }
+  await install();
 }
 
-export { install, installAll, conditionalInstall, doInstall };
+export { install, doInstall };

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -144,7 +144,6 @@ class ChromedriverStorageClient {
         continue;
       }
 
-      log.debug(`Processing chromedriver entry '${key}'`);
       const etag = extractNodeText(findChildNode(driverNode, 'ETag'));
       if (!etag) {
         log.debug(`The entry '${key}' does not contain the checksum. Skipping it`);

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -1,4 +1,7 @@
-import { getChromedriverDir, CD_CDN, retrieveData } from './utils';
+import {
+  getChromedriverDir, CD_CDN, retrieveData, getOsInfo,
+  OS, X64, X86, M1_ARCH_SUFFIX,
+} from './utils';
 import _ from 'lodash';
 import xpath from 'xpath';
 import { DOMParser } from 'xmldom';
@@ -12,19 +15,6 @@ const MAX_PARALLEL_DOWNLOADS = 5;
 
 const log = logger.getLogger('ChromedriverStorageClient');
 
-
-async function getOsInfo () {
-  let name = 'linux';
-  if (system.isWindows()) {
-    name = 'win';
-  } else if (system.isMac()) {
-    name = 'mac';
-  }
-  return {
-    name,
-    arch: await system.arch(),
-  };
-}
 
 async function isCrcOk (src, checksum) {
   const md5 = await fs.hash(src, 'md5');
@@ -254,6 +244,8 @@ class ChromedriverStorageClient {
    * Can be either `mac`, `windows` or `linux`
    * @property {string} arch - The architecture of the host OD.
    * Can be either `32` or `64`
+   * @property {?string} hardwareName - The output of `uname -m` command
+   * on linux and mac systems. `null` on Windows
    */
 
   /**
@@ -261,7 +253,7 @@ class ChromedriverStorageClient {
    * chromedriver entries by operating system information
    * and/or additional synchronization options (if provided)
    *
-   * @param {OSInfo} osInfo
+   * @param {?OSInfo} osInfo
    * @param {?SyncOptions} opts
    * @returns {Array<String>} The list of filtered chromedriver
    * entry names (version/archive name)
@@ -312,13 +304,19 @@ class ChromedriverStorageClient {
 
     if (!_.isEmpty(osInfo)) {
       // Filter out drivers for unsupported system architectures
-      let {name, arch} = osInfo;
-      if (arch === '64' && !driversToSync.some((cdName) => cdName.includes(`_${name}64`))) {
+      let {name, arch, hardwareName} = osInfo;
+      if (arch === X64 && !driversToSync.some((cdName) => cdName.includes(`_${name}${X64}`))) {
         // Fall back to x86 build if x64 one is not available for the given OS
-        arch = '32';
+        arch = X86;
+      }
+      if (name === OS.mac && _.includes(hardwareName, 'arm')
+          && driversToSync.some((cdName) => cdName.includes(M1_ARCH_SUFFIX))) {
+        // prefer executable for M1 arch if present
+        arch += M1_ARCH_SUFFIX;
       }
       log.debug(`Selecting chromedrivers whose platform matches to ${name}${arch}`);
-      driversToSync = driversToSync.filter((cdName) => cdName.includes(`_${name}${arch}`));
+      const platformRe = new RegExp(`(\\b|_)${name}${arch}(\\b|_)`);
+      driversToSync = driversToSync.filter((cdName) => platformRe.test(cdName));
       log.debug(`Got ${util.pluralize('item', driversToSync.length, true)}`);
     }
 
@@ -390,6 +388,9 @@ class ChromedriverStorageClient {
    * @property {string|number} minBrowserVersion - The minumum supported
    * Chrome version that downloaded chromedrivers should support. Can match
    * multiple drivers.
+   * @property {?OSInfo} osInfo - System information used to filter out
+   * the list of the retrieved drivers. If not provided then the script
+   * will try to retrieve it.
    */
 
   /**
@@ -409,7 +410,7 @@ class ChromedriverStorageClient {
       throw new Error('Cannot retrieve chromedrivers mapping from Google storage');
     }
 
-    const driversToSync = this.selectMatchingDrivers(await getOsInfo(), opts);
+    const driversToSync = this.selectMatchingDrivers(opts.osInfo ?? await getOsInfo(), opts);
     if (_.isEmpty(driversToSync)) {
       log.debug(`There are no drivers to sync. Exiting`);
       return [];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,6 +52,9 @@ async function getChromedriverBinaryPath (osName = getOsName()) {
   const paths = await fs.glob(`${CD_EXECUTABLE_PREFIX}*${pathSuffix}`, {
     cwd: rootDir,
     absolute: true,
+    nocase: true,
+    nodir: true,
+    strict: false,
   });
   return _.isEmpty(paths)
     ? path.resolve(rootDir, `${CD_EXECUTABLE_PREFIX}${pathSuffix}`)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,13 +48,13 @@ function getChromedriverDir (osName = getOsName()) {
 
 async function getChromedriverBinaryPath (osName = getOsName()) {
   const rootDir = getChromedriverDir(osName);
-  const paths = await fs.glob(`${CD_EXECUTABLE_PREFIX}*`, {
+  const pathSuffix = osName === OS.windows ? '.exe' : '';
+  const paths = await fs.glob(`${CD_EXECUTABLE_PREFIX}*${pathSuffix}`, {
     cwd: rootDir,
     absolute: true,
   });
-  const defaultName = `${CD_EXECUTABLE_PREFIX}${osName === OS.windows ? '.exe' : ''}`;
   return _.isEmpty(paths)
-    ? path.resolve(rootDir, defaultName)
+    ? path.resolve(rootDir, `${CD_EXECUTABLE_PREFIX}${pathSuffix}`)
     : _.first(paths);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { system } from 'appium-support';
+import { system, fs } from 'appium-support';
 import path from 'path';
-import semver from 'semver';
 import compareVersions from 'compare-versions';
 import axios from 'axios';
+import { exec } from 'teen_process';
 
 
 const rootDir = path.basename(__dirname) === 'lib'
@@ -19,9 +19,15 @@ const CD_BASE_DIR = path.resolve(__dirname, '..', '..', 'chromedriver');
 const CD_CDN = process.env.npm_config_chromedriver_cdnurl
   || process.env.CHROMEDRIVER_CDNURL
   || 'https://chromedriver.storage.googleapis.com';
-
-const MAC_32_ONLY = '2.23.0';
-const LINUX_32_ONLY = '2.34.0';
+const OS = {
+  linux: 'linux',
+  windows: 'win',
+  mac: 'mac'
+};
+const X64 = '64';
+const X86 = '32';
+const M1_ARCH_SUFFIX = '_m1';
+const CD_EXECUTABLE_PREFIX = 'chromedriver';
 
 
 function getMostRecentChromedriver (mapping = CHROMEDRIVER_CHROME_MAPPING) {
@@ -36,39 +42,20 @@ async function getChromeVersion (adb, bundleId) {
   return versionName;
 }
 
-function getChromedriverDir (platform = getCurPlatform()) {
-  return path.resolve(CD_BASE_DIR, platform);
+function getChromedriverDir (osName = getOsName()) {
+  return path.resolve(CD_BASE_DIR, osName);
 }
 
-async function getChromedriverBinaryPath (platform = getCurPlatform(), arch = null) {
-  const baseDir = getChromedriverDir(platform);
-  let ext = '';
-  if (platform === 'win') {
-    ext = '.exe';
-  } else if (platform === 'linux') {
-    ext = `_${arch || await system.arch()}`;
-  }
-
-  return path.resolve(baseDir, `chromedriver${ext}`);
-}
-
-function getCurPlatform () {
-  return system.isWindows() ? 'win' : (system.isMac() ? 'mac' : 'linux');
-}
-
-function getPlatforms () {
-  let plats = [
-    ['win', '32'],
-    ['linux', '64'],
-  ];
-  const cdVer = semver.coerce(CD_VER);
-  // before 2.23 Mac version was 32 bit. After it is 64.
-  plats.push(semver.lt(cdVer, MAC_32_ONLY) ? ['mac', '32'] : ['mac', '64']);
-  // 2.34 and above linux is only supporting 64 bit
-  if (semver.lt(cdVer, LINUX_32_ONLY)) {
-    plats.push(['linux', '32']);
-  }
-  return plats;
+async function getChromedriverBinaryPath (osName = getOsName()) {
+  const rootDir = getChromedriverDir(osName);
+  const paths = await fs.glob(`${CD_EXECUTABLE_PREFIX}*`, {
+    cwd: rootDir,
+    absolute: true,
+  });
+  const defaultName = `${CD_EXECUTABLE_PREFIX}${osName === OS.windows ? '.exe' : ''}`;
+  return _.isEmpty(paths)
+    ? path.resolve(rootDir, defaultName)
+    : _.first(paths);
 }
 
 async function retrieveData (url, headers, opts = {}) {
@@ -84,10 +71,27 @@ async function retrieveData (url, headers, opts = {}) {
   })).data;
 }
 
+const getOsName = _.memoize(function getOsName () {
+  if (system.isWindows()) {
+    return OS.windows;
+  }
+  if (system.isMac()) {
+    return OS.mac;
+  }
+  return OS.linux;
+});
+
+const getOsInfo = _.memoize(async function getOsInfo () {
+  return {
+    name: getOsName(),
+    arch: await system.arch(),
+    hardwareName: system.isWindows() ? null : _.trim(await exec('uname', ['-m'])),
+  };
+});
+
 
 export {
-  getChromeVersion, getChromedriverDir, getChromedriverBinaryPath,
-  getCurPlatform, getPlatforms, CD_BASE_DIR, MAC_32_ONLY, LINUX_32_ONLY,
-  CD_CDN, CD_VER, CHROMEDRIVER_CHROME_MAPPING, getMostRecentChromedriver,
-  retrieveData,
+  getChromeVersion, getChromedriverDir, getChromedriverBinaryPath, getOsName,
+  CD_BASE_DIR, CD_CDN, CD_VER, CHROMEDRIVER_CHROME_MAPPING, getMostRecentChromedriver,
+  retrieveData, getOsInfo, OS, X64, X86, M1_ARCH_SUFFIX,
 };

--- a/test/install-e2e-specs.js
+++ b/test/install-e2e-specs.js
@@ -3,9 +3,10 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { fs } from 'appium-support';
-import { install, installAll } from '../lib/install';
-import { CD_BASE_DIR, getChromedriverBinaryPath, getPlatforms,
-         getCurPlatform } from '../lib/utils';
+import { install } from '../lib/install';
+import {
+  CD_BASE_DIR, getChromedriverBinaryPath, getOsName
+} from '../lib/utils';
 import Chromedriver from '../lib/chromedriver';
 
 
@@ -34,27 +35,10 @@ describe('install scripts', function () {
     let cdPath = await getChromedriverBinaryPath();
     let cdStat = await fs.stat(cdPath);
     cdStat.size.should.be.above(500000);
-    cdPath.should.contain(getCurPlatform());
+    cdPath.should.contain(getOsName());
     let cd = new Chromedriver();
     await cd.initChromedriverPath();
     cd.chromedriver.should.equal(cdPath);
-  });
-  it('should install for all platforms', async function () {
-    this.timeout(120000);
-    await assertNoPreviousDirs();
-    await installAll();
-
-    for (let [platform, arch] of getPlatforms()) {
-      let cdPath = await getChromedriverBinaryPath(platform, arch);
-      let cdStat = await fs.stat(cdPath);
-      cdStat.size.should.be.above(500000);
-      cdPath.should.contain(platform);
-      if (platform === 'linux') {
-        cdPath.should.contain(arch);
-      } else {
-        cdPath.should.not.contain(arch);
-      }
-    }
   });
   it('should throw an error in chromedriver if nothing is installed', async function () {
     await assertNoPreviousDirs();


### PR DESCRIPTION
Now there are separate chromedriver build for M1 mac architecture. Also, the stuff inside of `install.js` mostly duplicates the content of chromedriver storage, so I've refactored it to avoid the unnecessary duplication.