### PR TITLE
docs: add .npmrc skip method to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ The solution, however, is simple. Simple run `gulp transpile` and then `npm inst
 
 If, for some reason, you want to install without installing the Chromedriver
 binary, either set the `APPIUM_SKIP_CHROMEDRIVER_INSTALL` environment variable,
-or pass the `--chromedriver-skip-install` flag while running `npm install`.
+pass the `--chromedriver-skip-install` flag while running `npm install`
+or add the following property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
+
+```bash
+chromedriver_skip_install=true
+```
 
 
 ## Usage


### PR DESCRIPTION
Add documentation that informs how to skip installation by using the .npmrc file. Refers to https://github.com/appium/appium/issues/15220.