### PR TITLE
fix: Update platform filter regex

### DIFF
--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -314,7 +314,7 @@ class ChromedriverStorageClient {
         arch += M1_ARCH_SUFFIX;
       }
       log.debug(`Selecting chromedrivers whose platform matches to ${name}${arch}`);
-      const platformRe = new RegExp(`(\\b|_)${name}${arch}(\\b|_)`);
+      const platformRe = new RegExp(`(\\b|_)${name}${arch}\\b`);
       driversToSync = driversToSync.filter((cdName) => platformRe.test(cdName));
       log.debug(`Got ${util.pluralize('item', driversToSync.length, true)}`);
     }


### PR DESCRIPTION
Currently the M1 executable is also selected on an Intel-based Mac, because `_mac64` is a part of `_mac64_m1`. This fix changes that