### PR TITLE
Fix misleading errmsg when driver doesn't support Chrome version

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -528,11 +528,15 @@ class Chromedriver extends events.EventEmitter {
       }
 
       let message = '';
-      // often the user's Chrome version is too low for the version of Chromedriver
+      // often the user's Chrome version is not supported by the version of Chromedriver
       if (e.message.includes('Chrome version must be')) {
-        message += 'Unable to automate Chrome version because it is too old for this version of Chromedriver.\n';
+        message += 'Unable to automate Chrome version because it is not supported by this version of Chromedriver.\n';
         if (webviewVersion) {
           message += `Chrome version on the device: ${webviewVersion}\n`;
+        }
+        const versionsSupportedByDriver = /Chrome version must be (.+)/.exec(e.message)?.[1] || '';
+        if (versionsSupportedByDriver) {
+          message += `Chromedriver supports Chrome version(s): ${versionsSupportedByDriver}\n`;
         }
         message += `Visit '${CHROMEDRIVER_TUTORIAL}' to troubleshoot the problem.\n`;
       }


### PR DESCRIPTION
The old message ("Unable to automate Chrome version because it's too
old for this version of Chromedriver") assumes a situation. I, on the
other hand, encountered a situation where the version of the Chrome
browser was higher than the versions the Chromedriver could handle.

So instead of assuming things, a regexp was added to extract the
supported Chrome versions by Chromedriver, and display them on a
separate line.