### PR TITLE
refactor: Switch the module to use direct dependencies to appium rather then peer dependencies

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -1,9 +1,9 @@
 // transpile:main
 
 import events from 'events';
-import { JWProxy, PROTOCOLS } from 'appium/driver';
+import { JWProxy, PROTOCOLS } from '@appium/base-driver';
 import cp from 'child_process';
-import { system, fs, logger, util } from 'appium/support';
+import { system, fs, logger, util } from '@appium/support';
 import { retryInterval, asyncmap } from 'asyncbox';
 import { SubProcess, exec } from 'teen_process';
 import B from 'bluebird';

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,4 +1,4 @@
-import { fs, mkdirp } from 'appium/support';
+import { fs, mkdirp } from '@appium/support';
 import ChromedriverStorageClient from './storage-client';
 import {
   CD_CDN, CD_VER, retrieveData, getOsInfo, getChromedriverDir,

--- a/lib/protocol-helpers.js
+++ b/lib/protocol-helpers.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { isStandardCap } from 'appium/driver';
+import { isStandardCap } from '@appium/base-driver';
 
 const W3C_PREFIX = 'goog:';
 

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -7,7 +7,7 @@ import xpath from 'xpath';
 import { DOMParser } from '@xmldom/xmldom';
 import B from 'bluebird';
 import path from 'path';
-import { system, fs, logger, tempDir, zip, util, net } from 'appium/support';
+import { system, fs, logger, tempDir, zip, util, net } from '@appium/support';
 
 
 const TIMEOUT_MS = 15000;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { system, fs } from 'appium/support';
-import { BaseDriver } from 'appium/driver';
+import { system, fs } from '@appium/support';
+import { BaseDriver } from '@appium/base-driver';
 import path from 'path';
 import compareVersions from 'compare-versions';
 import axios from 'axios';

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "config/mapping.json"
   ],
   "dependencies": {
+    "@appium/base-driver": "^8.6.0",
+    "@appium/support": "^2.59.3",
     "@babel/runtime": "^7.0.0",
     "@xmldom/xmldom": "^0.x",
     "asyncbox": "^2.0.2",
@@ -66,9 +68,6 @@
     "precommit-test": "REPORTER=dot gulp once",
     "lint": "gulp lint",
     "lint:fix": "gulp lint --fix"
-  },
-  "peerDependencies": {
-    "appium": "^2.0.0-beta.40"
   },
   "devDependencies": {
     "@appium/gulp-plugins": "^7.0.0",

--- a/test/chromedriver-specs.js
+++ b/test/chromedriver-specs.js
@@ -3,7 +3,7 @@ import * as utils from '../lib/utils';
 import sinon from 'sinon';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { fs } from 'appium/support';
+import { fs } from '@appium/support';
 import * as tp from 'teen_process';
 import path from 'path';
 import _ from 'lodash';

--- a/test/install-e2e-specs.js
+++ b/test/install-e2e-specs.js
@@ -2,7 +2,7 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { fs } from 'appium/support';
+import { fs } from '@appium/support';
 import { install } from '../lib/install';
 import {
   CD_BASE_DIR, getChromedriverBinaryPath, getOsName

--- a/test/storage-client-e2e-specs.js
+++ b/test/storage-client-e2e-specs.js
@@ -4,7 +4,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import ChromedriverStorageClient from '../lib/storage-client';
 import _ from 'lodash';
-import { fs, tempDir } from 'appium/support';
+import { fs, tempDir } from '@appium/support';
 
 
 chai.should();


### PR DESCRIPTION
This is just an experiment related to https://github.com/appium/appium/pull/17288

Perhaps by switching this module the postinstall script would start working as expected