### PR TITLE
chore: customize the changelog

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,24 @@
         {"type": "chore", "release": "patch"}
       ]
     }],
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/release-notes-generator",
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          {"type": "feat", "section": "Features"},
+          {"type": "fix", "section": "Bug Fixes"},
+          {"type": "perf", "section": "Performance Improvements"},
+          {"type": "revert", "section": "Reverts"},
+          {"type": "chore", "section": "Miscellaneous Chores"},
+          {"type": "refactor", "section": "Code Refactoring"},
+          {"type": "docs", "section": "Documentation", "hidden": true},
+          {"type": "style", "section": "Styles", "hidden": true},
+          {"type": "test", "section": "Tests", "hidden": true},
+          {"type": "build", "section": "Build System", "hidden": true},
+          {"type": "ci", "section": "Continuous Integration", "hidden": true}
+        ]
+      }
+    ],
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],


### PR DESCRIPTION
Maybe this will create `refactor` and `chore` sections in the release note as well.
In the default angular one only print feat, fix and perf.

https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/writer-opts.js
https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type
We should set `conventionalcommits` and manually everything to customize it. This PR is based on the angular one, and I have change the `hidden` status in a few to show non-hidden status ones in the release note.

This PR title has `chore` for testing