### PR TITLE
fix: minBrowserVersion in SyncOption should be a number

### DIFF
--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -7,6 +7,7 @@ import {
   X64,
   X86,
   APPLE_ARM_SUFFIXES,
+  convertToInt,
 } from './utils';
 import _ from 'lodash';
 import xpath from 'xpath';
@@ -296,10 +297,11 @@ class ChromedriverStorageClient {
       }
     }
 
-    if (minBrowserVersion && !Number.isNaN(minBrowserVersion)) {
+    const minBrowserVersionInt = convertToInt(minBrowserVersion);
+    if (minBrowserVersionInt) {
       // Only select drivers that support the current browser whose major version number equals to `minBrowserVersion`
       log.debug(
-        `Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersion}`
+        `Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersionInt}`
       );
       let closestMatchedVersionNumber = 0;
       // Select the newest available and compatible chromedriver
@@ -310,7 +312,7 @@ class ChromedriverStorageClient {
         );
         if (
           !Number.isNaN(currentMinBrowserVersion) &&
-          currentMinBrowserVersion <= minBrowserVersion &&
+          currentMinBrowserVersion <= minBrowserVersionInt &&
           closestMatchedVersionNumber < currentMinBrowserVersion
         ) {
           closestMatchedVersionNumber = currentMinBrowserVersion;
@@ -319,7 +321,7 @@ class ChromedriverStorageClient {
       driversToSync = driversToSync.filter(
         (cdName) =>
           `${this.mapping[cdName].minBrowserVersion}` ===
-          `${closestMatchedVersionNumber > 0 ? closestMatchedVersionNumber : minBrowserVersion}`
+          `${closestMatchedVersionNumber > 0 ? closestMatchedVersionNumber : minBrowserVersionInt}`
       );
 
       log.debug(`Got ${util.pluralize('item', driversToSync.length, true)}`);

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -298,7 +298,7 @@ class ChromedriverStorageClient {
     }
 
     const minBrowserVersionInt = convertToInt(minBrowserVersion);
-    if (minBrowserVersionInt) {
+    if (minBrowserVersionInt !== null) {
       // Only select drivers that support the current browser whose major version number equals to `minBrowserVersion`
       log.debug(
         `Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersionInt}`

--- a/lib/storage-client.js
+++ b/lib/storage-client.js
@@ -296,11 +296,10 @@ class ChromedriverStorageClient {
       }
     }
 
-    if (_.isString(minBrowserVersion) && !Number.isNaN(minBrowserVersion)) {
+    if (minBrowserVersion && !Number.isNaN(minBrowserVersion)) {
       // Only select drivers that support the current browser whose major version number equals to `minBrowserVersion`
-      const minBrowserVersionInt = parseInt(minBrowserVersion, 10);
       log.debug(
-        `Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersionInt}`
+        `Selecting chromedrivers whose minimum supported browser version matches to ${minBrowserVersion}`
       );
       let closestMatchedVersionNumber = 0;
       // Select the newest available and compatible chromedriver
@@ -311,7 +310,7 @@ class ChromedriverStorageClient {
         );
         if (
           !Number.isNaN(currentMinBrowserVersion) &&
-          currentMinBrowserVersion <= minBrowserVersionInt &&
+          currentMinBrowserVersion <= minBrowserVersion &&
           closestMatchedVersionNumber < currentMinBrowserVersion
         ) {
           closestMatchedVersionNumber = currentMinBrowserVersion;
@@ -320,7 +319,7 @@ class ChromedriverStorageClient {
       driversToSync = driversToSync.filter(
         (cdName) =>
           `${this.mapping[cdName].minBrowserVersion}` ===
-          `${closestMatchedVersionNumber > 0 ? closestMatchedVersionNumber : minBrowserVersionInt}`
+          `${closestMatchedVersionNumber > 0 ? closestMatchedVersionNumber : minBrowserVersion}`
       );
 
       log.debug(`Got ${util.pluralize('item', driversToSync.length, true)}`);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,7 +30,7 @@ export interface SyncOptions {
    * The minumum supported Chrome version that downloaded chromedrivers should
    * support. Can match multiple drivers.
    */
-  minBrowserVersion?: number;
+  minBrowserVersion?: string | number;
   /**
    * System information used to filter out the list of the retrieved drivers. If
    * not provided then the script will try to retrieve it.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,7 +30,7 @@ export interface SyncOptions {
    * The minumum supported Chrome version that downloaded chromedrivers should
    * support. Can match multiple drivers.
    */
-  minBrowserVersion?: string | number;
+  minBrowserVersion?: number;
   /**
    * System information used to filter out the list of the retrieved drivers. If
    * not provided then the script will try to retrieve it.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,6 +156,9 @@ function generateLogPrefix(obj, sessionId = null) {
 function convertToInt(value) {
   switch (typeof value) {
     case 'number':
+      if (Number.isNaN(value)) {
+        return null;
+      }
       return value;
     case 'string': {
       const parsedAsInt = parseInt(value, 10);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -151,24 +151,19 @@ function generateLogPrefix(obj, sessionId = null) {
  * Converts the given object to an integer number if possible
  *
  * @param {any} value to be converted
- * @returns {number?}
+ * @returns {number | null}
  */
 function convertToInt(value) {
   switch (typeof value) {
     case 'number':
-      if (Number.isNaN(value)) {
-        return null;
-      }
-      return value;
+      return Number.isNaN(value) ? null : value;
     case 'string': {
       const parsedAsInt = parseInt(value, 10);
-      if (!Number.isNaN(parsedAsInt)) {
-        return parsedAsInt;
-      }
-      return null;
+      return Number.isNaN(parsedAsInt) ? null : parsedAsInt;
     }
+    default:
+      return null;
   }
-  return null;
 }
 
 export {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,6 +147,27 @@ function generateLogPrefix(obj, sessionId = null) {
   );
 }
 
+/**
+ * Converts the given object to an integer number if possible
+ *
+ * @param {any} value to be converted
+ * @returns {number?}
+ */
+function convertToInt(value) {
+  switch (typeof value) {
+    case 'number':
+      return value;
+    case 'string': {
+      const parsedAsInt = parseInt(value, 10);
+      if (!Number.isNaN(parsedAsInt)) {
+        return parsedAsInt;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
 export {
   getChromeVersion,
   getChromedriverDir,
@@ -164,4 +185,5 @@ export {
   X86,
   APPLE_ARM_SUFFIXES,
   generateLogPrefix,
+  convertToInt,
 };

--- a/test/functional/storage-client-e2e-specs.js
+++ b/test/functional/storage-client-e2e-specs.js
@@ -41,7 +41,7 @@ describe('ChromedriverStorageClient', function () {
     });
     try {
       (await client.syncDrivers({
-        minBrowserVersion: '44',
+        minBrowserVersion: 44,
       })).length.should.be.greaterThan(0);
       (await fs.readdir(tmpRoot)).length.should.be.greaterThan(0);
     } finally {
@@ -56,7 +56,7 @@ describe('ChromedriverStorageClient', function () {
     });
     try {
       (await client.syncDrivers({
-        minBrowserVersion: '74',
+        minBrowserVersion: 74,
       })).length.should.be.greaterThan(0);
       (await fs.readdir(tmpRoot)).length.should.be.greaterThan(0);
     } finally {

--- a/test/unit/storage-client-specs.js
+++ b/test/unit/storage-client-specs.js
@@ -165,7 +165,7 @@ describe('ChromedriverStorageClient', function () {
         name: 'mac',
         arch: '64',
       }, {
-        minBrowserVersion: '60',
+        minBrowserVersion: 60,
       });
       selectedDrivers.should.eql([
         '76.0.3809.12/chromedriver_mac64.zip',
@@ -180,7 +180,7 @@ describe('ChromedriverStorageClient', function () {
         arch: '64',
       }, {
         versions: ['76.0.3809.12'],
-        minBrowserVersion: '60',
+        minBrowserVersion: 60,
       });
       selectedDrivers.should.eql([
         '76.0.3809.12/chromedriver_mac64.zip',

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,0 +1,32 @@
+import {convertToInt} from '../../lib/utils';
+import chai from 'chai';
+
+chai.should();
+const should = chai.should();
+
+describe('utils', function () {
+  describe('convertToInt', function () {
+    it('should parse a number', function () {
+      convertToInt(0).should.eql(0);
+      convertToInt(1).should.eql(1);
+      convertToInt(100).should.eql(100);
+    });
+    it('should return null with NaN', function () {
+      should.not.exist(convertToInt(NaN));
+    });
+    it('should parse a number string', function () {
+      convertToInt('0').should.eql(0);
+      convertToInt('1.1').should.eql(1);
+      convertToInt('-123').should.eql(-123);
+    });
+    it('should return null if non numer string is given', function () {
+      should.not.exist(convertToInt(''));
+      should.not.exist(convertToInt('foo'));
+    });
+    it('should return null if unexpected type', function () {
+      should.not.exist(convertToInt({}));
+      should.not.exist(convertToInt(null));
+      should.not.exist(convertToInt(true));
+    });
+  });
+});


### PR DESCRIPTION
## Issue to fix
This PR fixes an issue where selectMatchingDrivers() ignores `minBroswerVersion` and attempts to download a lot of unnecessary ChromeDrviers.

[Here is a log](https://github.com/appium/appium-uiautomator2-driver/suites/11504452138/artifacts/594646158). While it can detect the Chrome version, it doesn't filter with the minimum browser version. 
```
...... (At Line 12996)
2023-03-12 08:12:37:097 - [debug] [Chromedriver@558d] [Chromedriver@558d] Browser version in the supplied details: Chrome/66.0.3359.158
2023-03-12 08:12:37:097 - [debug] [Chromedriver@558d] [Chromedriver@558d] Found Chrome bundle 'undefined' version '66.0.3359'
...
... (At Line 16182)
2023-03-12 08:12:41:829 - [debug] [ChromedriverStorageClient] [ChromedriverStorageClient] Selecting chromedrivers whose platform matches to mac64
2023-03-12 08:12:41:831 - [debug] [ChromedriverStorageClient] [ChromedriverStorageClient] Got 121 items
...
```

## Cause
[selectMatchingDrivers() assumes `minBrowserVersion` is a string](https://github.com/appium/appium-chromedriver/blob/e4e2a82664896fb654ceaa89dce64267871752b9/lib/storage-client.js#L299) but it's always a number as it's [given here](https://github.com/appium/appium-chromedriver/blob/25b1c64e6f70f1138f0a0e4ddffffb9ecae5575d/lib/chromedriver.js#L350) and the type of `Semver.chromeVersion.major` is number. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/semver/classes/semver.d.ts#L12