### PR TITLE
fix: install-npm.js fails to run npm run build due to type error

### DIFF
--- a/install-npm.js
+++ b/install-npm.js
@@ -10,6 +10,7 @@
  */
 
 const B = require('bluebird');
+const util = require('util')
 
 // this is here because we're using async/await, and this must be set _before_ we use async/await,
 // given that bluebird is used elsewhere via `doInstall()`.
@@ -37,7 +38,7 @@ async function main() {
     try {
       await exec(npmCommand, ['run', 'build'], {logger: log, cwd: __dirname});
     } catch (e) {
-      throw new Error(`appium-chromedriver package cannot be built: ${e.stderr || e.message}`);
+      throw new Error(`appium-chromedriver package cannot be built: ${util.inspect(e)}`);
     }
   }
 

--- a/install-npm.js
+++ b/install-npm.js
@@ -10,7 +10,7 @@
  */
 
 const B = require('bluebird');
-const util = require('util')
+const util = require('util');
 
 // this is here because we're using async/await, and this must be set _before_ we use async/await,
 // given that bluebird is used elsewhere via `doInstall()`.
@@ -32,8 +32,10 @@ async function main() {
   try {
     await fs.stat(BUILD_PATH);
   } catch {
-    log.info(`The Chromedriver install script cannot be found at '${BUILD_PATH}'. ` +
-      `Building appium-chromedriver package`);
+    log.info(
+      `The Chromedriver install script cannot be found at '${BUILD_PATH}'. ` +
+        `Building appium-chromedriver package`
+    );
     const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     try {
       await exec(npmCommand, ['run', 'build'], {logger: log, cwd: __dirname});
@@ -48,11 +50,9 @@ async function main() {
     !_.isEmpty(process.env.npm_config_chromedriver_skip_install)
   ) {
     log.warn(
-      `'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable is set; skipping Chromedriver installation.`,
+      `'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable is set; skipping Chromedriver installation.`
     );
-    log.warn(
-      `Android web/hybrid testing will not be possible without Chromedriver.`,
-    );
+    log.warn(`Android web/hybrid testing will not be possible without Chromedriver.`);
     return;
   }
 
@@ -63,7 +63,7 @@ async function main() {
     log.error(err.stack ? err.stack : err);
     log.error(
       `Downloading Chromedriver can be skipped by setting the` +
-        `'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable.`,
+        `'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable.`
     );
     process.exit(1);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,6 +131,9 @@ const getOsInfo = _.memoize(
   }
 );
 
+// @ts-expect-error
+// error TS2345: Argument of type '{}' is not assignable to parameter of type 'DriverOpts<Readonly<Record<string, Constraint>>>'
+// Type '{}' is missing the following properties from type 'ServerArgs': address, allowCors, allowInsecure, basePath, and 26 more.
 const getBaseDriverInstance = _.memoize(() => new BaseDriver({}, false));
 
 /**


### PR DESCRIPTION
`node install-npm.js` in the current main branch doesn't work due to tsc error.
e.g. https://github.com/appium/appium-chromedriver/actions/runs/4403909094/jobs/7720201682

After letting it show the error details with `util.inspect(e)`, npm install failed like this:
```
npm install
npm WARN config init.author.name Use `--init-author-name` instead.
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'semantic-release@20.1.1',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.15.1', npm: '8.11.0' }
npm WARN EBADENGINE }

> appium-chromedriver@5.3.0 postinstall
> node install-npm.js

[23:50:48] The Chromedriver install script cannot be found at '/Users/rerorero/go/src/github.com/rerorero/appium-chromedriver/build/lib/install.js'. Building appium-chromedriver package

/Users/rerorero/go/src/github.com/rerorero/appium-chromedriver/node_modules/teen_process/lib/exec.js:129
        let err = new Error(`Command '${rep}' exited with code ${code}`);
                  ^
Error: appium-chromedriver package cannot be built: Error: Command 'npm run build' exited with code 1
    at ChildProcess.<anonymous> (/Users/rerorero/go/src/github.com/rerorero/appium-chromedriver/node_modules/teen_process/lib/exec.js:129:19)
    at ChildProcess.emit (node:events:527:28)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  stdout: '\n' +
    '> appium-chromedriver@5.3.0 build\n' +
    '> tsc -b\n' +
    '\n' +
    "lib/utils.js(134,62): error TS2345: Argument of type '{}' is not assignable to parameter of type 'DriverOpts<Readonly<Record<string, Constraint>>>'.\n" +
    "  Type '{}' is missing the following properties from type 'ServerArgs': address, allowCors, allowInsecure, basePath, and 26 more.\n",
  stderr: 'npm WARN config init.author.name Use `--init-author-name` instead.\n',
  code: 1
}
    at main (/Users/rerorero/go/src/github.com/rerorero/appium-chromedriver/install-npm.js:41:13)
npm ERR! code 1
npm ERR! path /Users/rerorero/go/src/github.com/rerorero/appium-chromedriver
npm ERR! command failed
npm ERR! command sh -c node install-npm.js

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rerorero/.npm/_logs/2023-03-14T14_50_47_686Z-debug-0.log
```
