### PR TITLE
fix: start session should return caps that chromedriver returns

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -138,7 +138,7 @@ export class Chromedriver extends events.EventEmitter {
     });
     this.log.debug(
       `Found ${util.pluralize('executable', executables.length, true)} ` +
-        `in '${this.executableDir}'`
+        `in '${this.executableDir}'`,
     );
     const cds = (
       await asyncmap(executables, async (executable) => {
@@ -148,7 +148,7 @@ export class Chromedriver extends events.EventEmitter {
         const logError = ({message, stdout, stderr}) => {
           let errMsg =
             `Cannot retrieve version number from '${path.basename(
-              executable
+              executable,
             )}' Chromedriver binary. ` +
             `Make sure it returns a valid version string in response to '--version' command line argument. ${message}`;
           if (stdout) {
@@ -219,7 +219,7 @@ export class Chromedriver extends events.EventEmitter {
       this.log.debug(
         `    '${cd.executable}' (version '${cd.version}', minimum Chrome version '${
           cd.minChromeVersion ? cd.minChromeVersion : 'Unknown'
-        }')`
+        }')`,
       );
     }
     return cds;
@@ -313,7 +313,7 @@ export class Chromedriver extends events.EventEmitter {
         const err = /** @type {Error} */ (e);
         this.log.warn(
           `Cannot store the updated chromedrivers mapping into '${this.mappingPath}'. ` +
-            `This may reduce the performance of further executions. Original error: ${err.message}`
+            `This may reduce the performance of further executions. Original error: ${err.message}`,
         );
       }
     }
@@ -348,7 +348,7 @@ export class Chromedriver extends events.EventEmitter {
       const retrievedMapping = await this.storageClient.retrieveMapping();
       this.log.debug(
         'Got chromedrivers mapping from the storage: ' +
-        _.truncate(JSON.stringify(retrievedMapping, null, 2), {length: 500})
+          _.truncate(JSON.stringify(retrievedMapping, null, 2), {length: 500}),
       );
       const driverKeys = await this.storageClient.syncDrivers({
         minBrowserVersion: chromeVersion.major,
@@ -388,7 +388,7 @@ export class Chromedriver extends events.EventEmitter {
             `which ${
               _.size(missingVersions) === 1 ? 'is' : 'are'
             } missing in the list of known versions: ` +
-            JSON.stringify(missingVersions)
+            JSON.stringify(missingVersions),
         );
         await this.updateDriversMapping(Object.assign(mapping, missingVersions));
       }
@@ -397,15 +397,15 @@ export class Chromedriver extends events.EventEmitter {
         if (_.isEmpty(cds)) {
           this.log.errorAndThrow(
             `There must be at least one Chromedriver executable available for use if ` +
-              `'chromedriverDisableBuildCheck' capability is set to 'true'`
+              `'chromedriverDisableBuildCheck' capability is set to 'true'`,
           );
         }
         const {version, executable} = cds[0];
         this.log.warn(
-          `Chrome build check disabled. Using most recent Chromedriver version (${version}, at '${executable}')`
+          `Chrome build check disabled. Using most recent Chromedriver version (${version}, at '${executable}')`,
         );
         this.log.warn(
-          `If this is wrong, set 'chromedriverDisableBuildCheck' capability to 'false'`
+          `If this is wrong, set 'chromedriverDisableBuildCheck' capability to 'false'`,
         );
         return executable;
       }
@@ -416,12 +416,12 @@ export class Chromedriver extends events.EventEmitter {
         if (_.isEmpty(cds)) {
           this.log.errorAndThrow(
             `There must be at least one Chromedriver executable available for use if ` +
-              `the current Chrome version cannot be determined`
+              `the current Chrome version cannot be determined`,
           );
         }
         const {version, executable} = cds[0];
         this.log.warn(
-          `Unable to discover Chrome version. Using Chromedriver ${version} at '${executable}'`
+          `Unable to discover Chrome version. Using Chromedriver ${version} at '${executable}'`,
         );
         return executable;
       }
@@ -446,7 +446,7 @@ export class Chromedriver extends events.EventEmitter {
           } catch (e) {
             const err = /** @type {Error} */ (e);
             this.log.warn(
-              `Cannot synchronize local chromedrivers with the remote storage: ${err.message}`
+              `Cannot synchronize local chromedrivers with the remote storage: ${err.message}`,
             );
             this.log.debug(err.stack);
           }
@@ -456,18 +456,18 @@ export class Chromedriver extends events.EventEmitter {
           'a possible workaround.';
         throw new Error(
           `No Chromedriver found that can automate Chrome '${chromeVersion}'.` +
-            (this.storageClient ? '' : ` ${autodownloadSuggestion}`)
+            (this.storageClient ? '' : ` ${autodownloadSuggestion}`),
         );
       }
 
       const binPath = matchingDrivers[0].executable;
       this.log.debug(
         `Found ${util.pluralize('executable', matchingDrivers.length, true)} ` +
-          `capable of automating Chrome '${chromeVersion}'.\nChoosing the most recent, '${binPath}'.`
+          `capable of automating Chrome '${chromeVersion}'.\nChoosing the most recent, '${binPath}'.`,
       );
       this.log.debug(
         'If a specific version is required, specify it with the `chromedriverExecutable`' +
-          'desired capability.'
+          'desired capability.',
       );
       return binPath;
       // eslint-disable-next-line no-constant-condition
@@ -492,7 +492,7 @@ export class Chromedriver extends events.EventEmitter {
     if (!(await fs.exists(chromedriver))) {
       throw new Error(
         `Trying to use a chromedriver binary at the path ` +
-          `${this.chromedriver}, but it doesn't exist!`
+          `${this.chromedriver}, but it doesn't exist!`,
       );
     }
     this.executableVerified = true;
@@ -514,7 +514,7 @@ export class Chromedriver extends events.EventEmitter {
     if (!coercedVersion || coercedVersion.major < MIN_CD_VERSION_WITH_W3C_SUPPORT) {
       this.log.debug(
         `The WebDriver v. ${this.driverVersion} does not fully support ${PROTOCOLS.W3C} protocol. ` +
-          `Defaulting to ${PROTOCOLS.MJSONWP}`
+          `Defaulting to ${PROTOCOLS.MJSONWP}`,
       );
       return;
     }
@@ -524,7 +524,7 @@ export class Chromedriver extends events.EventEmitter {
     if (chromeOptions.w3c === false) {
       this.log.info(
         `The WebDriver v. ${this.driverVersion} supports ${PROTOCOLS.W3C} protocol, ` +
-          `but ${PROTOCOLS.MJSONWP} one has been explicitly requested`
+          `but ${PROTOCOLS.MJSONWP} one has been explicitly requested`,
       );
       return;
     }
@@ -664,7 +664,7 @@ export class Chromedriver extends events.EventEmitter {
       // start subproc and wait for startDetector
       await this.proc.start(startDetector);
       await this.waitForOnline();
-      await this.startSession();
+      return await this.startSession();
     } catch (e) {
       const err = /** @type {Error} */ (e);
       this.log.debug(err);
@@ -737,11 +737,14 @@ export class Chromedriver extends events.EventEmitter {
         : {desiredCapabilities: this.capabilities};
     this.log.info(
       `Starting ${this.desiredProtocol} Chromedriver session with capabilities: ` +
-        JSON.stringify(sessionCaps, null, 2)
+        JSON.stringify(sessionCaps, null, 2),
     );
-    await this.jwproxy.command('/session', 'POST', sessionCaps);
+    const {capabilities} = /** @type {NewSessionResponse} */ (
+      await this.jwproxy.command('/session', 'POST', sessionCaps)
+    );
     this.log.prefix = generateLogPrefix(this, this.jwproxy.sessionId);
     this.changeState(Chromedriver.STATE_ONLINE);
+    return capabilities;
   }
 
   async stop(emitStates = true) {
@@ -863,4 +866,8 @@ Chromedriver.STATE_RESTARTING = 'restarting';
 
 /**
  * @typedef {import('./types').ChromedriverVersionMapping} ChromedriverVersionMapping
+ */
+
+/**
+ * @typedef {{capabilities: Record<string, any>}} NewSessionResponse
  */


### PR DESCRIPTION
To support webdriver BiDi, we need to actually return caps that chromedriver returns, since it contains the webSocketUrl value which we may not be able to predict.