### PR TITLE
fix: respect executableDir even non-adb environment such as desktop

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -44,7 +44,7 @@ export class Chromedriver extends events.EventEmitter {
       port = DEFAULT_PORT,
       useSystemExecutable = false,
       executable,
-      executableDir = getChromedriverDir(),
+      executableDir,
       bundleId,
       mappingPath,
       cmdArgs,
@@ -74,6 +74,15 @@ export class Chromedriver extends events.EventEmitter {
       port: this.proxyPort,
       log: this._log,
     });
+
+    if (this.executableDir) {
+      // Expects the user set the executable directory explicitly
+      this.isCustomExecutableDir = true
+    } else {
+      this.isCustomExecutableDir = false
+      this.executableDir = getChromedriverDir()
+    }
+
     this.verbose = verbose;
     this.logPath = logPath;
     this.disableBuildCheck = !!disableBuildCheck;
@@ -326,7 +335,7 @@ export class Chromedriver extends events.EventEmitter {
    * @returns {Promise<string>}
    */
   async getCompatibleChromedriver() {
-    if (!this.adb && !this.executableDir) {
+    if (!this.adb && !this.isCustomExecutableDir) {
       return await getChromedriverBinaryPath();
     }
 

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -332,6 +332,8 @@ export class Chromedriver extends events.EventEmitter {
   }
 
   /**
+   * When executableDir is given explicitly for non-adb environment,
+   * this method will respect the executableDir rather than the system installed binary.
    * @returns {Promise<string>}
    */
   async getCompatibleChromedriver() {

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -326,6 +326,10 @@ export class Chromedriver extends events.EventEmitter {
    * @returns {Promise<string>}
    */
   async getCompatibleChromedriver() {
+    if (!this.adb && !this.executableDir) {
+      return await getChromedriverBinaryPath();
+    }
+
     const mapping = await this.getDriversMapping();
     if (!_.isEmpty(mapping)) {
       this.log.debug(`The most recent known Chrome version: ${_.values(mapping)[0]}`);

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -326,10 +326,6 @@ export class Chromedriver extends events.EventEmitter {
    * @returns {Promise<string>}
    */
   async getCompatibleChromedriver() {
-    if (!this.adb) {
-      return await getChromedriverBinaryPath();
-    }
-
     const mapping = await this.getDriversMapping();
     if (!_.isEmpty(mapping)) {
       this.log.debug(`The most recent known Chrome version: ${_.values(mapping)[0]}`);

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -77,10 +77,10 @@ export class Chromedriver extends events.EventEmitter {
 
     if (this.executableDir) {
       // Expects the user set the executable directory explicitly
-      this.isCustomExecutableDir = true
+      this.isCustomExecutableDir = true;
     } else {
-      this.isCustomExecutableDir = false
-      this.executableDir = getChromedriverDir()
+      this.isCustomExecutableDir = false;
+      this.executableDir = getChromedriverDir();
     }
 
     this.verbose = verbose;

--- a/test/unit/chromedriver-specs.js
+++ b/test/unit/chromedriver-specs.js
@@ -31,13 +31,19 @@ describe('chromedriver', function () {
         binPath.should.eql('/path/to/chromedriver');
       });
 
-      it('should respect executableDir', async function () {
-        sandbox.stub(utils, 'getChromedriverBinaryPath');
+      it('should search specified directory if provided', async function () {
+        const cd = new Chromedriver({
+          executableDir: '/some/local/dir/for/chromedrivers',
+        });
 
-        const cd = new Chromedriver({executableDir: '/path/to/executableDir'});
+        sandbox.stub(utils, 'getChromeVersion').returns('63.0.3239.99');
+        sandbox.stub(fs, 'glob').returns(['/some/local/dir/for/chromedrivers/chromedriver']);
+        sandbox.stub(tp, 'exec').returns({
+          stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
+        });
+
         const binPath = await cd.getCompatibleChromedriver();
-
-        getChromedriverBinaryPathSpy.called.once;
+        binPath.should.eql('/some/local/dir/for/chromedrivers/chromedriver');
       });
     });
 

--- a/test/unit/chromedriver-specs.js
+++ b/test/unit/chromedriver-specs.js
@@ -30,6 +30,15 @@ describe('chromedriver', function () {
         const binPath = await cd.getCompatibleChromedriver();
         binPath.should.eql('/path/to/chromedriver');
       });
+
+      it('should respect executableDir', async function () {
+        sandbox.stub(utils, 'getChromedriverBinaryPath');
+
+        const cd = new Chromedriver({executableDir: '/path/to/executableDir'});
+        const binPath = await cd.getCompatibleChromedriver();
+
+        getChromedriverBinaryPathSpy.called.once;
+      });
     });
 
     describe('Android', function () {


### PR DESCRIPTION
When executableDir is given, it would be nice to respect executableDir rather than forcefully use system's one for non-adb env such as desktop.

Current implementation does not respect given `executableDir` for non-adb environment. It means automatic detection/download does not work by `getCompatibleChromedriver`. 