### PR TITLE
chore: bump semantic-release from 23.1.1 to 24.0.0 and conventional-changelog-conventionalcommits to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,11 +85,11 @@
     "@types/teen_process": "^2.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "conventional-changelog-conventionalcommits": "^7.0.1",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "mocha": "^10.0.0",
     "prettier": "^3.0.0",
     "rimraf": "^5.0.0",
-    "semantic-release": "^23.0.0",
+    "semantic-release": "^24.0.0",
     "sinon": "^17.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.2"


### PR DESCRIPTION
…hangelog-conventionalcommits to 8.0.0