### PR TITLE
fix(storage-client): `parseFromString` requires valid mimeType

### DIFF
--- a/lib/storage-client/googleapis.js
+++ b/lib/storage-client/googleapis.js
@@ -95,7 +95,7 @@ export function parseNotes(content) {
  * @returns {Promise<ChromedriverDetailsMapping>}
  */
 export async function parseGoogleapiStorageXml(xml, shouldParseNotes = true) {
-  const doc = new DOMParser().parseFromString(xml);
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
   const driverNodes = /** @type {Array<Node|Attr>} */ (
     xpath.select(`//*[local-name(.)='Contents']`, doc)
   );


### PR DESCRIPTION
This PR fixes error caused by recent version of https://www.npmjs.com/package/@xmldom/xmldom/v/0.9.0 where mimeType became required argument.

```bash
# This file contains the result of Yarn building a package (appium-chromedriver@npm:5.6.73)
# Script name: postinstall

ERR! CDInstaller Error installing Chromedriver: DOMParser.parseFromString: the provided mimeType "undefined" is not valid.
ERR! CDInstaller TypeError: DOMParser.parseFromString: the provided mimeType "undefined" is not valid.
ERR! CDInstaller     at DOMParser.parseFromString (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/@xmldom/xmldom/lib/dom-parser.js:215:9)
ERR! CDInstaller     at parseGoogleapiStorageXml (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/lib/storage-client/googleapis.js:98:31)
ERR! CDInstaller     at ChromedriverStorageClient.retrieveMapping (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/lib/storage-client/storage-client.js:97:59)
ERR! CDInstaller     at ChromedriverStorageClient.syncDrivers (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/lib/storage-client/storage-client.js:357:7)
ERR! CDInstaller     at install (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/lib/install.js:57:3)
ERR! CDInstaller     at Object.doInstall (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/lib/install.js:64:3)
ERR! CDInstaller     at main (/Users/krystofwoldrich/repos/sentry-react-native/dev-packages/e2e-tests/node_modules/appium-chromedriver/install-npm.js:66:5)
ERR! CDInstaller Downloading Chromedriver can be skipped by setting the'APPIUM_SKIP_CHROMEDRIVER_INSTALL' environment variable.

```