### PR TITLE
feat: add get latest known good version

### DIFF
--- a/lib/storage-client/storage-client.js
+++ b/lib/storage-client/storage-client.js
@@ -19,7 +19,7 @@ import {
   CPU,
 } from '../constants';
 import {parseGoogleapiStorageXml} from './googleapis';
-import {parseKnownGoodVersionsWithDownloadsJson} from './chromelabs';
+import {parseKnownGoodVersionsWithDownloadsJson, parseLatestKnownGoodVersionsJson} from './chromelabs';
 import {compareVersions} from 'compare-versions';
 import semver from 'semver';
 
@@ -31,6 +31,8 @@ const STORAGE_INFOS = /** @type {readonly StorageInfo[]} */ ([{
   url: `${CHROMELABS_URL}/chrome-for-testing/known-good-versions-with-downloads.json`,
   accept: 'application/json',
 }]);
+
+const CHROME_FOR_TESTING_LAST_GOOD_VERSIONS = `${CHROMELABS_URL}/chrome-for-testing/last-known-good-versions.json`;
 
 const log = logger.getLogger('ChromedriverStorageClient');
 
@@ -406,6 +408,29 @@ export class ChromedriverStorageClient {
       log.info(`No chromedrivers were synchronized`);
     }
     return synchronizedDrivers;
+  }
+
+  /**
+   * Return latest chromedriver version for Chrome for Testing.
+   * @returns {Promise<string>}
+   */
+  async getLatestKnownGoodVersion () {
+    let jsonStr;
+    try {
+      jsonStr = await retrieveData(
+        CHROME_FOR_TESTING_LAST_GOOD_VERSIONS,
+        {
+          'user-agent': USER_AGENT,
+          accept: `application/json, */*`,
+        }, {timeout: STORAGE_REQ_TIMEOUT_MS}
+      );
+    } catch (e) {
+      const err = /** @type {Error} */ (e);
+      throw new Error(`Cannot fetch the latest Chromedriver version. ` +
+        `Make sure you can access ${CHROME_FOR_TESTING_LAST_GOOD_VERSIONS} from your machine or provide a mirror by setting ` +
+        `a custom value to CHROMELABS_URL enironment variable. Original error: ${err.message}`);
+    }
+    return parseLatestKnownGoodVersionsJson(jsonStr);
   }
 }
 

--- a/test/helpers/install.js
+++ b/test/helpers/install.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { fs, mkdirp } from '@appium/support';
 import ChromedriverStorageClient from '../../lib/storage-client/storage-client';
 import {

--- a/test/helpers/install.js
+++ b/test/helpers/install.js
@@ -1,41 +1,10 @@
 import _ from 'lodash';
 import { fs, mkdirp } from '@appium/support';
 import ChromedriverStorageClient from '../../lib/storage-client/storage-client';
-import {parseLatestKnownGoodVersionsJson} from '../../lib/storage-client/chromelabs';
 import {
-  CD_VER, retrieveData, getOsInfo, getChromedriverDir,
+  CD_VER, getOsInfo, getChromedriverDir,
 } from '../../lib/utils';
-import { USER_AGENT, STORAGE_REQ_TIMEOUT_MS, CHROMELABS_URL } from '../../lib/constants';
 
-const LATEST_VERSION = 'LATEST';
-
-/**
- *
- * @param {string} ver
- * @returns {Promise<string>}
- */
-async function formatCdVersion (ver) {
-  if (_.toUpper(ver) !== LATEST_VERSION) {
-    return ver;
-  }
-
-  let jsonStr;
-  const url = `${CHROMELABS_URL}/chrome-for-testing/last-known-good-versions.json`;
-  try {
-    jsonStr = await retrieveData(
-      url, {
-        'user-agent': USER_AGENT,
-        accept: `application/json, */*`,
-      }, {timeout: STORAGE_REQ_TIMEOUT_MS}
-    );
-  } catch (e) {
-    const err = /** @type {Error} */ (e);
-    throw new Error(`Cannot fetch the latest Chromedriver version. ` +
-      `Make sure you can access ${url} from your machine or provide a mirror by setting ` +
-      `a custom value to CHROMELABS_URL enironment variable. Original error: ${err.message}`);
-  }
-  return parseLatestKnownGoodVersionsJson(jsonStr);
-}
 
 /**
  *
@@ -54,8 +23,11 @@ export async function install () {
   const client = new ChromedriverStorageClient({
     chromedriverDir: await prepareChromedriverDir(osInfo.name),
   });
+  const chromeDriverVersion = CD_VER === 'LATEST'
+    ? CD_VER
+    : await client.getLatestKnownGoodVersion();
   await client.syncDrivers({
     osInfo,
-    versions: [await formatCdVersion(CD_VER)],
+    versions: [chromeDriverVersion],
   });
 }

--- a/test/helpers/install.js
+++ b/test/helpers/install.js
@@ -23,8 +23,8 @@ export async function install () {
     chromedriverDir: await prepareChromedriverDir(osInfo.name),
   });
   const chromeDriverVersion = CD_VER === 'LATEST'
-    ? CD_VER
-    : await client.getLatestKnownGoodVersion();
+    ? await client.getLatestKnownGoodVersion()
+    : CD_VER;
   await client.syncDrivers({
     osInfo,
     versions: [chromeDriverVersion],

--- a/test/helpers/install.js
+++ b/test/helpers/install.js
@@ -4,6 +4,7 @@ import {
   CD_VER, getOsInfo, getChromedriverDir,
 } from '../../lib/utils';
 
+const LATEST_VERSION = 'LATEST';
 
 /**
  *
@@ -22,7 +23,7 @@ export async function install () {
   const client = new ChromedriverStorageClient({
     chromedriverDir: await prepareChromedriverDir(osInfo.name),
   });
-  const chromeDriverVersion = CD_VER === 'LATEST'
+  const chromeDriverVersion = CD_VER === LATEST_VERSION
     ? await client.getLatestKnownGoodVersion()
     : CD_VER;
   await client.syncDrivers({


### PR DESCRIPTION
In `ChromedriverStorageClient`. The caller can get the latest one via `await client.getLatestKnownGoodVersion();`  The latest version is only via chrome labs today.