### PR TITLE
fix: use the entire response for non-w3c response format case

### DIFF
--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -763,9 +763,11 @@ export class Chromedriver extends events.EventEmitter {
       `Starting ${this.desiredProtocol} Chromedriver session with capabilities: ` +
         JSON.stringify(sessionCaps, null, 2),
     );
-    const {capabilities} = /** @type {NewSessionResponse} */ (
+    const respondedCapabilities = /** @type {NewSessionResponse} */ (
       await this.jwproxy.command('/session', 'POST', sessionCaps)
     );
+    // Only operadriver could only return MJSONWP format response in MJSONWP in the non-w3c mode.
+    const capabilities = respondedCapabilities.capabilities || respondedCapabilities;
     this.log.prefix = generateLogPrefix(this, this.jwproxy.sessionId);
     this.changeState(Chromedriver.STATE_ONLINE);
     return capabilities;

--- a/lib/chromedriver.js
+++ b/lib/chromedriver.js
@@ -766,7 +766,7 @@ export class Chromedriver extends events.EventEmitter {
     const respondedCapabilities = /** @type {NewSessionResponse} */ (
       await this.jwproxy.command('/session', 'POST', sessionCaps)
     );
-    // Only operadriver could only return MJSONWP format response in MJSONWP in the non-w3c mode.
+    // Only operadriver could return only MJSONWP format response in MJSONWP mode.
     const capabilities = respondedCapabilities.capabilities || respondedCapabilities;
     this.log.prefix = generateLogPrefix(this, this.jwproxy.sessionId);
     this.changeState(Chromedriver.STATE_ONLINE);


### PR DESCRIPTION
This is a minimal fix case idea.

`this.desiredProtocol` itself was properly handled in https://github.com/appium/appium/issues/20924 logs, but operadriver didn't include `capabilities` like below for non-w3c capability case.

> {"sessionId":"df33a11f6ced9a50c75ecb7474c8b35c","status":0,"value":{"acceptInsecureCerts":false,"acceptSslCerts":false,"browserConnectionEnabled":false,"browserName":"chrome","cssSelectorsEnabled":true,"databaseEnabled":false,"fedcm:accounts":true,"goog:chromeOptions":{"debuggerAddress":"localhost:57143"},"handlesAlerts":true,"hasTouchScreen":false,"javascriptEnabled":true,"locationContextEnabled":true,"mobileEmulationEnabled":false,"nativeEvents":true,"networkConnectionEnabled":false,"opera":{"operadriverVersion":"130.0.6723.137 (59d46b95c01984a5b09c060a98a17d81eafc2f11-refs/branch-heads/6723@{#2247})","userDataDir":"C:\\Users\\scoba\\AppData\\Local\\Temp\\scoped_dir16464_1652217617"},"pageLoadStrategy":"normal","platform":"Windows","proxy":{},"rotatable":false,"setWindowRect":true,"strictFileInteractability":false,"takesHeapSnapshot":true,"takesScreenshot":true,"timeouts":{"implicit":0,"pageLoad":300000,"script":30000},"unexpectedAlertBehaviour":"ignore","version":"130.0.6723.170","webStorageEnabled":tru...

I initially did:

```
const capabilities = this.desiredProtocol === PROTOCOLS.W3C
  ? respondedCapabilities.capabilities
  : respondedCapabilities;
```

but if this was only for operadriver, simply we can do `respondedCapabilities.capabilities | respondedCapabilities`.


I haven't tested anything yet. We may need to double check `w3c: false` 's chromedriver behavior as well.

I think chromedriver returned both formats by default for non-w3c as well but it could be wrong.

Another idea is do the `syncProtocol` method based on the actual response (if it includes `capabilities` or not) also could be a good idea? But then, if `w3c: false` in chromedriver returned both formats, it doesn't work expected I guess...


The original motivation for this response was to return the responded capabilities to use for `caps.webSocketUrl` in the caller side with this responded value only. So sync again might not be necessary.