### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/appium/appium/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "prettier": {
     "bracketSpacing": false,
@@ -41,10 +41,10 @@
   ],
   "types": "./build/lib/index.d.ts",
   "dependencies": {
-    "@appium/base-driver": "^9.1.0",
-    "@appium/support": "^6.0.0",
+    "@appium/base-driver": "^10.0.0-rc.2",
+    "@appium/support": "^7.0.0-rc.1",
     "@xmldom/xmldom": "^0.x",
-    "appium-adb": "^12.0.0",
+    "appium-adb": "^13.0.0",
     "asyncbox": "^3.0.0",
     "axios": "^1.6.5",
     "bluebird": "^3.5.1",
@@ -52,7 +52,7 @@
     "lodash": "^4.17.4",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.2.0",
+    "teen_process": "^3.0.0",
     "xpath": "^0.x"
   },
   "scripts": {
@@ -67,9 +67,9 @@
     "e2e-test": "mocha --exit --timeout 10m \"./test/functional/**/*-specs.js\""
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.x",
-    "@appium/test-support": "^3.0.0",
-    "@appium/tsconfig": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/test-support": "^4.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",

--- a/test/functional/chromedriver-e2e-specs.js
+++ b/test/functional/chromedriver-e2e-specs.js
@@ -44,7 +44,7 @@ function buildReqRes(url, method, body) {
   res.status = (code) => {
     res.sentCode = code;
     return {
-      send: (body) => {
+      json: (body) => {
         try {
           body = JSON.parse(body);
         } catch {}


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10