### PR TITLE
feat(chromedriver): optionally pre-grant Android runtime permissions to Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ function runSession2() {
 }
 ```
 
+## Granting Android runtime permissions to Chrome
+
+On Android, Chrome may interrupt an automated session with a native runtime-permission
+dialog the first time a page uses geolocation, the camera (`getUserMedia`), or file
+download/upload. Because that dialog is a native OS prompt rather than web content,
+Chromedriver cannot dismiss it and the session stalls.
+
+Pass the `grantPermissions` option (requires an `adb` instance) to pre-grant the relevant
+permissions to the Chrome package once the driver is online. It is disabled by default:
+
+```js
+// grant a sensible default set (camera, fine/coarse location, read/write storage)
+const driver = new Chromedriver({adb, grantPermissions: true});
+
+// or grant a specific set
+const driver = new Chromedriver({
+  adb,
+  grantPermissions: ['android.permission.ACCESS_FINE_LOCATION'],
+});
+```
+
+A failure to grant (e.g. the permission is not a runtime permission on the device) is
+logged as a warning and never aborts the session.
+
 ## States
 
 Here's what the Chromedriver state machine looks like:

--- a/lib/chromedriver.ts
+++ b/lib/chromedriver.ts
@@ -4,7 +4,12 @@ import {logger, util} from '@appium/support';
 import {SubProcess, exec} from 'teen_process';
 import {getChromedriverDir, generateLogPrefix} from './utils';
 import {ChromedriverStorageClient} from './storage-client/storage-client';
-import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from './constants';
+import {
+  CHROMEDRIVER_EVENTS,
+  CHROMEDRIVER_STATES,
+  CHROME_BUNDLE_ID,
+  DEFAULT_CHROME_PERMISSIONS,
+} from './constants';
 import {
   getDriversMapping,
   getChromedrivers,
@@ -52,6 +57,7 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
   readonly proxyPort: number;
   readonly adb?: ADB;
   readonly cmdArgs?: string[];
+  readonly grantPermissions?: ChromedriverOpts['grantPermissions'];
   proc: SubProcess | null;
   readonly useSystemExecutable: boolean;
   chromedriver?: string;
@@ -108,12 +114,14 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
       details,
       isAutodownloadEnabled = false,
       reqBasePath,
+      grantPermissions,
     } = args;
     this._log = logger.getLogger(generateLogPrefix(this));
     this.proxyHost = host;
     this.proxyPort = parseInt(String(port), 10);
     this.adb = adb;
     this.cmdArgs = cmdArgs;
+    this.grantPermissions = grantPermissions;
     this.proc = null;
     this.useSystemExecutable = useSystemExecutable;
     this.chromedriver = executable;
@@ -178,6 +186,35 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
       return await this.startSession();
     } catch (e) {
       return await this.handleChromedriverStartFailure(e as Error, webviewVersionHolder.version);
+    }
+  }
+
+  /**
+   * Pre-grants Android runtime permissions to the Chrome package so the session is not
+   * interrupted by a native permission dialog (geolocation, camera, file access, ...).
+   * Controlled by the `grantPermissions` option and a no-op unless `adb` is available.
+   * Failures are logged and swallowed so they never abort an otherwise healthy session.
+   */
+  async grantDefaultPermissions(): Promise<void> {
+    if (!this.adb) {
+      this.log.debug('Skipping permission grant: no adb instance is available');
+      return;
+    }
+    const bundleId = this.bundleId ?? CHROME_BUNDLE_ID;
+    const permissions = Array.isArray(this.grantPermissions)
+      ? this.grantPermissions
+      : [...DEFAULT_CHROME_PERMISSIONS];
+    if (permissions.length === 0) {
+      return;
+    }
+    try {
+      this.log.info(`Granting permissions ${JSON.stringify(permissions)} to '${bundleId}'`);
+      await this.adb.grantPermissions(bundleId, permissions);
+    } catch (e) {
+      this.log.warn(
+        `Could not grant permissions to '${bundleId}': ${(e as Error).message}. ` +
+          `Features that rely on these permissions might require manual interaction.`,
+      );
     }
   }
 
@@ -334,6 +371,9 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
     await this.proc.start(chromedriverStdoutStartDetector);
     // wait until /status says ready, then negotiate protocol and start session
     await this.waitForOnline();
+    if (this.grantPermissions) {
+      await this.grantDefaultPermissions();
+    }
   }
 
   private formatChromeVersionMismatchHint(err: Error, webviewVersion?: string): string {

--- a/lib/commands/version.ts
+++ b/lib/commands/version.ts
@@ -1,8 +1,8 @@
 import * as semver from 'semver';
 import {getChromeVersion} from '../utils';
+import {CHROME_BUNDLE_ID} from '../constants';
 import type {ChromedriverCommandContext} from './types';
 
-const CHROME_BUNDLE_ID = 'com.android.chrome';
 const WEBVIEW_SHELL_BUNDLE_ID = 'org.chromium.webview_shell';
 const WEBVIEW_BUNDLE_IDS = ['com.google.android.webview', 'com.android.webview'] as const;
 const VERSION_PATTERN = /([\d.]+)/;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -35,3 +35,19 @@ export const CHROMEDRIVER_STATES = {
   STOPPING: 'stopping',
   RESTARTING: 'restarting',
 } as const;
+
+export const CHROME_BUNDLE_ID = 'com.android.chrome';
+
+/**
+ * Android runtime permissions granted to the Chrome package when `grantPermissions` is
+ * enabled. These cover what web automation most commonly needs (camera for getUserMedia,
+ * location for the Geolocation API, storage for download/upload) so Chrome does not
+ * interrupt the session with a native permission dialog.
+ */
+export const DEFAULT_CHROME_PERMISSIONS = [
+  'android.permission.CAMERA',
+  'android.permission.ACCESS_FINE_LOCATION',
+  'android.permission.ACCESS_COARSE_LOCATION',
+  'android.permission.WRITE_EXTERNAL_STORAGE',
+  'android.permission.READ_EXTERNAL_STORAGE',
+] as const;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,14 @@ export interface ChromedriverOpts {
   details?: {info?: {Browser: string}};
   isAutodownloadEnabled?: boolean;
   reqBasePath?: string;
+  /**
+   * Grant Android runtime permissions to the Chrome package (`bundleId`, defaulting to
+   * `com.android.chrome`) once the driver is online, so the session is not blocked by a
+   * native permission dialog. `true` grants a default set (see `DEFAULT_CHROME_PERMISSIONS`);
+   * an array grants the provided `android.permission.*` names instead. Requires `adb`.
+   * Disabled by default.
+   */
+  grantPermissions?: boolean | string[];
 }
 
 export type ChromedriverVersionMapping = Record<string, string | null>;

--- a/test/unit/chromedriver-specs.ts
+++ b/test/unit/chromedriver-specs.ts
@@ -1,6 +1,7 @@
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {Chromedriver} from '../../lib/chromedriver';
+import {CHROME_BUNDLE_ID, DEFAULT_CHROME_PERMISSIONS} from '../../lib/constants';
 import sinon from 'sinon';
 import {fs} from '@appium/support';
 import path from 'node:path';
@@ -303,6 +304,57 @@ describe('chromedriver', function () {
     });
     it('should fail for empty mapping', function () {
       expect(() => utils.getMostRecentChromedriver({})).to.throw(/empty/);
+    });
+  });
+
+  describe('grantDefaultPermissions', function () {
+    it('should be a no-op when no adb is available', async function () {
+      const cd = new Chromedriver({grantPermissions: true});
+      // should resolve without throwing even though there is no adb
+      await cd.grantDefaultPermissions();
+    });
+
+    it('should grant the default permission set to the Chrome package', async function () {
+      const grantStub = sinon.stub().resolves();
+      const cd = new Chromedriver({
+        adb: {grantPermissions: grantStub} as any,
+        grantPermissions: true,
+      });
+      await cd.grantDefaultPermissions();
+      expect(grantStub.calledOnce).to.be.true;
+      expect(grantStub.firstCall.args[0]).to.eql(CHROME_BUNDLE_ID);
+      expect(grantStub.firstCall.args[1]).to.eql([...DEFAULT_CHROME_PERMISSIONS]);
+    });
+
+    it('should grant a custom permission list when provided as an array', async function () {
+      const grantStub = sinon.stub().resolves();
+      const perms = ['android.permission.CAMERA'];
+      const cd = new Chromedriver({
+        adb: {grantPermissions: grantStub} as any,
+        grantPermissions: perms,
+      });
+      await cd.grantDefaultPermissions();
+      expect(grantStub.firstCall.args[1]).to.eql(perms);
+    });
+
+    it('should target a custom bundleId when one is set', async function () {
+      const grantStub = sinon.stub().resolves();
+      const cd = new Chromedriver({
+        adb: {grantPermissions: grantStub} as any,
+        bundleId: 'com.android.chrome.beta',
+        grantPermissions: true,
+      });
+      await cd.grantDefaultPermissions();
+      expect(grantStub.firstCall.args[0]).to.eql('com.android.chrome.beta');
+    });
+
+    it('should swallow adb errors instead of failing the session', async function () {
+      const grantStub = sinon.stub().rejects(new Error('pm grant failed'));
+      const cd = new Chromedriver({
+        adb: {grantPermissions: grantStub} as any,
+        grantPermissions: true,
+      });
+      await expect(cd.grantDefaultPermissions()).to.eventually.be.fulfilled;
     });
   });
 });


### PR DESCRIPTION
## Problem

On Android, Chrome interrupts an automated session with a **native runtime-permission dialog** the first time a page uses geolocation, the camera (`getUserMedia`), or file download/upload. Because that dialog is a native OS prompt rather than web content, Chromedriver cannot see or dismiss it, so the session stalls or the feature under test fails.

Today the only workarounds are out-of-band `adb shell pm grant ...` calls before the session, which every Android web-automation setup has to reinvent.

## Fix

Add an **opt-in** `grantPermissions` option to `Chromedriver` (requires an `adb` instance). When set, the driver pre-grants the relevant runtime permissions to the Chrome package once it is online (right after `waitForOnline()`):

- `grantPermissions: true` → grants a sensible default set (camera, fine/coarse location, read/write storage).
- `grantPermissions: ['android.permission.…']` → grants exactly the provided list.

```js
const driver = new Chromedriver({adb, grantPermissions: true});
```

## Why it's generally useful (not vendor-specific)

- Any Android Chrome/WebView automation that exercises geolocation, camera, or file APIs hits this native-dialog problem.
- The implementation uses only existing primitives — `this.adb.grantPermissions`, `this.bundleId` (defaulting to `com.android.chrome`), the logger — and the standard `android.permission.*` names. No environment-specific assumptions.

## Backwards compatibility

- **Disabled by default** — existing behaviour is completely unchanged unless the new option is set.
- A grant failure (e.g. the permission isn't a runtime permission on the device, or Chrome isn't installed) is logged as a warning and swallowed, so it never aborts an otherwise healthy session.

## How tested

- New unit tests in `test/unit/chromedriver-specs.ts` cover: no-adb no-op, default set granted to `com.android.chrome`, custom permission list, custom `bundleId`, and error-swallowing on `adb.grantPermissions` rejection.
- `npm run build`, `npm run lint`, and `npm test` all pass locally (18 unit specs passing).
