### PR TITLE
feat!: Migrate the package to ESM

### DIFF
--- a/lib/chromedriver.ts
+++ b/lib/chromedriver.ts
@@ -2,29 +2,29 @@ import events from 'node:events';
 import {JWProxy, PROTOCOLS} from '@appium/base-driver';
 import {logger, util} from '@appium/support';
 import {SubProcess, exec} from 'teen_process';
-import {getChromedriverDir, generateLogPrefix} from './utils';
-import {ChromedriverStorageClient} from './storage-client/storage-client';
-import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from './constants';
+import {getChromedriverDir, generateLogPrefix} from './utils.js';
+import {ChromedriverStorageClient} from './storage-client/storage-client.js';
+import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from './constants.js';
 import {
   getDriversMapping,
   getChromedrivers,
   updateDriversMapping,
   getCompatibleChromedriver,
   initChromedriverPath,
-} from './commands/binary';
-import {getChromeVersionForAutodetection} from './commands/version';
-import {buildChromedriverArgs, waitForOnline, getStatus, killAll} from './commands/process';
+} from './commands/binary.js';
+import {getChromeVersionForAutodetection} from './commands/version.js';
+import {buildChromedriverArgs, waitForOnline, getStatus, killAll} from './commands/process.js';
 import {
   syncProtocol,
   startSession,
   changeState,
   getCapValue,
   type SessionCapabilities,
-} from './commands/session';
+} from './commands/session.js';
 import type {ADB} from 'appium-adb';
 import type {ProxyOptions, HTTPMethod, HTTPBody} from '@appium/types';
 import type {Request, Response} from 'express';
-import type {ChromedriverOpts} from './types';
+import type {ChromedriverOpts} from './types.js';
 
 // Keep this import marked as used at runtime when it is otherwise only referenced in type positions.
 void PROTOCOLS;

--- a/lib/commands/binary.ts
+++ b/lib/commands/binary.ts
@@ -4,9 +4,9 @@ import {compareVersions} from 'compare-versions';
 import {type ExecError} from 'teen_process';
 import path from 'node:path';
 import * as semver from 'semver';
-import {CHROMEDRIVER_CHROME_MAPPING, getChromedriverBinaryPath} from '../utils';
-import type {ChromedriverVersionMapping} from '../types';
-import type {ChromedriverCommandContext} from './types';
+import {CHROMEDRIVER_CHROME_MAPPING, getChromedriverBinaryPath} from '../utils.js';
+import type {ChromedriverVersionMapping} from '../types.js';
+import type {ChromedriverCommandContext} from './types.js';
 
 const NEW_CD_VERSION_FORMAT_MAJOR_VERSION = 73;
 const CD_VERSION_TIMEOUT = 5000;

--- a/lib/commands/process.ts
+++ b/lib/commands/process.ts
@@ -1,8 +1,8 @@
 import {system, util} from '@appium/support';
 import {retryInterval} from 'asyncbox';
 import {exec} from 'teen_process';
-import {CHROMEDRIVER_STATES} from '../constants';
-import type {ChromedriverCommandContext} from './types';
+import {CHROMEDRIVER_STATES} from '../constants.js';
+import type {ChromedriverCommandContext} from './types.js';
 
 const VERSION_PATTERN = /([\d.]+)/;
 

--- a/lib/commands/session.ts
+++ b/lib/commands/session.ts
@@ -1,9 +1,9 @@
 import {PROTOCOLS, isStandardCap} from '@appium/base-driver';
 import {util} from '@appium/support';
-import {generateLogPrefix} from '../utils';
-import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from '../constants';
+import {generateLogPrefix} from '../utils.js';
+import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from '../constants.js';
 import * as semver from 'semver';
-import type {ChromedriverCommandContext} from './types';
+import type {ChromedriverCommandContext} from './types.js';
 
 const MIN_CD_VERSION_WITH_W3C_SUPPORT = 75;
 const W3C_PREFIX = 'goog:';

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -4,8 +4,8 @@ import {PROTOCOLS, type JWProxy} from '@appium/base-driver';
 import type * as TeenProcess from 'teen_process';
 import type {ADB} from 'appium-adb';
 import type {AppiumLogger} from '@appium/types';
-import type {ChromedriverOpts} from '../types';
-import type {ChromedriverStorageClient} from '../storage-client/storage-client';
+import type {ChromedriverOpts} from '../types.js';
+import type {ChromedriverStorageClient} from '../storage-client/storage-client.js';
 import type {EventEmitter} from 'node:events';
 
 export interface ChromedriverCommandContext extends EventEmitter {

--- a/lib/commands/version.ts
+++ b/lib/commands/version.ts
@@ -1,6 +1,6 @@
 import * as semver from 'semver';
-import {getChromeVersion} from '../utils';
-import type {ChromedriverCommandContext} from './types';
+import {getChromeVersion} from '../utils.js';
+import type {ChromedriverCommandContext} from './types.js';
 
 const CHROME_BUNDLE_ID = 'com.android.chrome';
 const WEBVIEW_SHELL_BUNDLE_ID = 'org.chromium.webview_shell';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
-import {Chromedriver} from './chromedriver';
-export {ChromedriverStorageClient} from './storage-client/storage-client';
+import {Chromedriver} from './chromedriver.js';
+export {ChromedriverStorageClient} from './storage-client/storage-client.js';
 export default Chromedriver;
 export {Chromedriver};
-export type * from './types';
+export type * from './types.js';

--- a/lib/storage-client/chromelabs.ts
+++ b/lib/storage-client/chromelabs.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import {logger} from '@appium/support';
 import * as semver from 'semver';
-import {ARCH, CPU} from '../constants';
-import type {ChromedriverDetailsMapping} from '../types';
+import {ARCH, CPU} from '../constants.js';
+import type {ChromedriverDetailsMapping} from '../types.js';
 
 interface VersionEntry {
   version: string;

--- a/lib/storage-client/googleapis.ts
+++ b/lib/storage-client/googleapis.ts
@@ -1,15 +1,21 @@
 import {select as xpathSelect} from 'xpath';
 import {util, logger} from '@appium/support';
-import {retrieveData} from '../utils';
+import {retrieveData} from '../utils.js';
 import {asyncmap} from 'asyncbox';
-import {STORAGE_REQ_TIMEOUT_MS, GOOGLEAPIS_CDN, ARCH, CPU, APPLE_ARM_SUFFIXES} from '../constants';
+import {
+  STORAGE_REQ_TIMEOUT_MS,
+  GOOGLEAPIS_CDN,
+  ARCH,
+  CPU,
+  APPLE_ARM_SUFFIXES,
+} from '../constants.js';
 import {DOMParser} from '@xmldom/xmldom';
 import path from 'node:path';
 import type {
   AdditionalDriverDetails,
   ChromedriverDetails,
   ChromedriverDetailsMapping,
-} from '../types';
+} from '../types.js';
 
 const log = logger.getLogger('ChromedriverGoogleapisStorageClient');
 const MAX_PARALLEL_DOWNLOADS = 5;

--- a/lib/storage-client/storage-client.ts
+++ b/lib/storage-client/storage-client.ts
@@ -1,4 +1,4 @@
-import {getChromedriverDir, retrieveData, getOsInfo, convertToInt, getCpuType} from '../utils';
+import {getChromedriverDir, retrieveData, getOsInfo, convertToInt, getCpuType} from '../utils.js';
 import path from 'node:path';
 import {asyncmap} from 'asyncbox';
 import {system, fs, logger, tempDir, zip, util, net} from '@appium/support';
@@ -10,12 +10,12 @@ import {
   ARCH,
   OS,
   CPU,
-} from '../constants';
-import {parseGoogleapiStorageXml} from './googleapis';
+} from '../constants.js';
+import {parseGoogleapiStorageXml} from './googleapis.js';
 import {
   parseKnownGoodVersionsWithDownloadsJson,
   parseLatestKnownGoodVersionsJson,
-} from './chromelabs';
+} from './chromelabs.js';
 import {compareVersions} from 'compare-versions';
 import * as semver from 'semver';
 import type {
@@ -23,7 +23,7 @@ import type {
   SyncOptions,
   OSInfo,
   ChromedriverDetailsMapping,
-} from '../types';
+} from '../types.js';
 
 const MAX_PARALLEL_DOWNLOADS = 5;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,13 +1,15 @@
 import {system, fs, node, util} from '@appium/support';
 import {BaseDriver} from '@appium/base-driver';
 import path from 'node:path';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
 import {compareVersions} from 'compare-versions';
 import axios from 'axios';
 import type {AxiosRequestConfig} from 'axios';
 import os from 'node:os';
-import {OS, CPU} from './constants';
+import {OS, CPU} from './constants.js';
 import type {ADB} from 'appium-adb';
-import type {ChromedriverVersionMapping, OSInfo} from './types';
+import type {ChromedriverVersionMapping, OSInfo} from './types.js';
 
 const CD_EXECUTABLE_PREFIX = 'chromedriver';
 const MODULE_NAME = 'appium-chromedriver';
@@ -18,7 +20,7 @@ const MODULE_NAME = 'appium-chromedriver';
  * @throws {Error} If the current module root folder cannot be determined
  */
 const getModuleRoot = util.memoize(function getModuleRoot(): string {
-  const root = node.getModuleRootSync(MODULE_NAME, __filename);
+  const root = node.getModuleRootSync(MODULE_NAME, fileURLToPath(import.meta.url));
   if (!root) {
     throw new Error(`Cannot find the root folder of the ${MODULE_NAME} Node.js module`);
   }
@@ -26,8 +28,8 @@ const getModuleRoot = util.memoize(function getModuleRoot(): string {
 });
 
 // Chromedriver version: minimum Chrome version
-export const CHROMEDRIVER_CHROME_MAPPING: ChromedriverVersionMapping = require(
-  path.join(getModuleRoot(), 'config', 'mapping.json'),
+export const CHROMEDRIVER_CHROME_MAPPING: ChromedriverVersionMapping = JSON.parse(
+  readFileSync(path.join(getModuleRoot(), 'config', 'mapping.json'), 'utf8'),
 );
 export const CD_BASE_DIR = path.join(getModuleRoot(), 'chromedriver');
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "singleQuote": true
   },
   "main": "./build/lib/index.js",
+  "type": "module",
   "directories": {
     "lib": "lib"
   },
@@ -36,6 +37,13 @@
     "CHANGELOG.md"
   ],
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@appium/base-driver": "^10.0.0-rc.2",
     "@appium/support": "^7.2.2",
@@ -57,8 +65,8 @@
     "prepare": "npm run build",
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
-    "test": "node --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
-    "e2e-test": "node --test --test-force-exit --test-concurrency=1 --test-timeout=600000 \"./build/test/functional/**/*.spec.js\""
+    "test": "node --enable-source-maps --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
+    "e2e-test": "node --enable-source-maps --test --test-force-exit --test-concurrency=1 --test-timeout=600000 \"./build/test/functional/**/*.spec.js\""
   },
   "devDependencies": {
     "@appium/eslint-config-appium-ts": "^3.0.0",
@@ -74,6 +82,7 @@
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",
+    "esmock": "^2.7.6",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",

--- a/test/functional/chromedriver-e2e.spec.ts
+++ b/test/functional/chromedriver-e2e.spec.ts
@@ -1,7 +1,7 @@
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {Chromedriver, type ChromedriverState} from '../../lib/chromedriver';
-import {install} from '../helpers/install';
+import {Chromedriver, type ChromedriverState} from '../../lib/chromedriver.js';
+import {install} from '../helpers/install.js';
 import {exec} from 'teen_process';
 import {describe, it, before} from 'node:test';
 

--- a/test/functional/storage-client-e2e.spec.ts
+++ b/test/functional/storage-client-e2e.spec.ts
@@ -1,6 +1,6 @@
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client';
+import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client.js';
 import {fs, tempDir} from '@appium/support';
 import {describe, it} from 'node:test';
 

--- a/test/helpers/install.ts
+++ b/test/helpers/install.ts
@@ -1,6 +1,6 @@
 import {fs} from '@appium/support';
-import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client';
-import {CD_VER, getOsInfo, getChromedriverDir} from '../../lib/utils';
+import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client.js';
+import {CD_VER, getOsInfo, getChromedriverDir} from '../../lib/utils.js';
 
 const LATEST_VERSION = 'LATEST';
 

--- a/test/unit/chromedriver.spec.ts
+++ b/test/unit/chromedriver.spec.ts
@@ -1,19 +1,36 @@
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {Chromedriver} from '../../lib/chromedriver';
 import sinon from 'sinon';
 import {fs, node} from '@appium/support';
 import path from 'node:path';
-import * as utils from '../../lib/utils';
+import {fileURLToPath} from 'node:url';
+import esmock from 'esmock';
+import * as utils from '../../lib/utils.js';
+import type * as ChromedriverModule from '../../lib/chromedriver.js';
 import {describe, beforeEach, afterEach, it, before} from 'node:test';
 
 const FIXTURES_DIR = path.resolve(
-  node.getModuleRootSync('appium-chromedriver', __filename)!,
+  node.getModuleRootSync('appium-chromedriver', fileURLToPath(import.meta.url))!,
   'test',
   'fixtures',
 );
 
 use(chaiAsPromised);
+
+let currentGetChromedriverBinaryPath: (...args: any[]) => any = utils.getChromedriverBinaryPath;
+let currentGetChromeVersion: (...args: any[]) => any = utils.getChromeVersion;
+
+const {Chromedriver} = await esmock<typeof ChromedriverModule>(
+  '../../lib/chromedriver.js',
+  import.meta.url,
+  {},
+  {
+    '../../lib/utils.js': {
+      getChromedriverBinaryPath: (...args: any[]) => currentGetChromedriverBinaryPath(...args),
+      getChromeVersion: (...args: any[]) => currentGetChromeVersion(...args),
+    },
+  },
+);
 
 describe('chromedriver', function () {
   let sandbox: sinon.SinonSandbox;
@@ -23,12 +40,14 @@ describe('chromedriver', function () {
   });
   afterEach(function () {
     sandbox.restore();
+    currentGetChromedriverBinaryPath = utils.getChromedriverBinaryPath;
+    currentGetChromeVersion = utils.getChromeVersion;
   });
 
   describe('getCompatibleChromedriver', function () {
     describe('desktop', function () {
       it('should find generic binary', async function () {
-        sandbox.stub(utils, 'getChromedriverBinaryPath').resolves('/path/to/chromedriver');
+        currentGetChromedriverBinaryPath = sandbox.stub().resolves('/path/to/chromedriver');
 
         const cd = new Chromedriver({});
         const binPath = await (cd as any).getCompatibleChromedriver();
@@ -40,7 +59,7 @@ describe('chromedriver', function () {
           executableDir: '/some/local/dir/for/chromedrivers',
         });
 
-        sandbox.stub(utils, 'getChromeVersion').resolves('63.0.3239.99');
+        currentGetChromeVersion = sandbox.stub().resolves('63.0.3239.99');
         sandbox.stub(fs, 'glob').resolves(['/some/local/dir/for/chromedrivers/chromedriver']);
         sandbox.stub(cd, '_execFunc').resolves({
           stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
@@ -52,7 +71,7 @@ describe('chromedriver', function () {
     });
 
     describe('Android', function () {
-      let cd: Chromedriver;
+      let cd: InstanceType<typeof Chromedriver>;
       let getChromedriverBinaryPathSpy: sinon.SinonSpy;
       before(function () {
         cd = new Chromedriver({
@@ -62,14 +81,15 @@ describe('chromedriver', function () {
         });
       });
       beforeEach(function () {
-        getChromedriverBinaryPathSpy = sandbox.spy(utils, 'getChromedriverBinaryPath');
+        getChromedriverBinaryPathSpy = sandbox.spy(utils.getChromedriverBinaryPath);
+        currentGetChromedriverBinaryPath = getChromedriverBinaryPathSpy;
       });
       afterEach(function () {
         expect(getChromedriverBinaryPathSpy.called).to.be.false;
       });
 
       it('should find a compatible binary if only one binary exists', async function () {
-        sandbox.stub(utils, 'getChromeVersion').resolves('63.0.3239.99');
+        currentGetChromeVersion = sandbox.stub().resolves('63.0.3239.99');
         sandbox.stub(fs, 'glob').resolves(['/path/to/chromedriver']);
         sandbox.stub(cd, '_execFunc').resolves({
           stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
@@ -80,7 +100,7 @@ describe('chromedriver', function () {
       });
 
       it('should find most recent compatible binary for older driver versions', async function () {
-        sandbox.stub(utils, 'getChromeVersion').resolves('70.0.3029.42');
+        currentGetChromeVersion = sandbox.stub().resolves('70.0.3029.42');
         sandbox
           .stub(fs, 'glob')
           .resolves([
@@ -195,7 +215,7 @@ describe('chromedriver', function () {
       });
 
       it('should fail when chrome is too new', async function () {
-        sandbox.stub(utils, 'getChromeVersion').resolves('10000.0.0.42');
+        currentGetChromeVersion = sandbox.stub().resolves('10000.0.0.42');
         sandbox
           .stub(fs, 'glob')
           .resolves([
@@ -234,7 +254,7 @@ describe('chromedriver', function () {
           executableDir: '/some/local/dir/for/chromedrivers',
         });
 
-        sandbox.stub(utils, 'getChromeVersion').resolves('63.0.3239.99');
+        currentGetChromeVersion = sandbox.stub().resolves('63.0.3239.99');
         sandbox.stub(fs, 'glob').resolves(['/some/local/dir/for/chromedrivers/chromedriver']);
         sandbox.stub(cd, '_execFunc').resolves({
           stdout: 'ChromeDriver 2.36.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
@@ -252,7 +272,7 @@ describe('chromedriver', function () {
           mappingPath: path.resolve(FIXTURES_DIR, 'alt-mapping.json'),
         });
 
-        sandbox.stub(utils, 'getChromeVersion').resolves('63.0.3239.99');
+        currentGetChromeVersion = sandbox.stub().resolves('63.0.3239.99');
         sandbox.stub(fs, 'glob').resolves(['/path/to/chromedriver-42']);
         sandbox.stub(cd, '_execFunc').resolves({
           stdout: 'ChromeDriver 2.42.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',
@@ -269,7 +289,7 @@ describe('chromedriver', function () {
           } as any,
           mappingPath: path.resolve(FIXTURES_DIR, 'alt-mapping-nonsemver.json'),
         });
-        sandbox.stub(utils, 'getChromeVersion').resolves('63.0.3239.99');
+        currentGetChromeVersion = sandbox.stub().resolves('63.0.3239.99');
         sandbox.stub(fs, 'glob').resolves(['/path/to/chromedriver-42']);
         sandbox.stub(cd, '_execFunc').resolves({
           stdout: 'ChromeDriver 2.42.540469 (1881fd7f8641508feb5166b7cae561d87723cfa8)',

--- a/test/unit/chromedriver.spec.ts
+++ b/test/unit/chromedriver.spec.ts
@@ -81,7 +81,9 @@ describe('chromedriver', function () {
         });
       });
       beforeEach(function () {
-        getChromedriverBinaryPathSpy = sandbox.spy(utils.getChromedriverBinaryPath);
+        getChromedriverBinaryPathSpy = sandbox
+          .stub()
+          .rejects(new Error('getChromedriverBinaryPath should not have been called'));
         currentGetChromedriverBinaryPath = getChromedriverBinaryPathSpy;
       });
       afterEach(function () {

--- a/test/unit/googleapi-storage-client.spec.ts
+++ b/test/unit/googleapi-storage-client.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {parseNotes} from '../../lib/storage-client/googleapis';
+import {parseNotes} from '../../lib/storage-client/googleapis.js';
 import {describe, it} from 'node:test';
 
 describe('GoogleapiChromedriverStorageClient', function () {

--- a/test/unit/protocol-helpers.spec.ts
+++ b/test/unit/protocol-helpers.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {toW3cCapNames, getCapValue} from '../../lib/commands/session';
+import {toW3cCapNames, getCapValue} from '../../lib/commands/session.js';
 import {describe, it} from 'node:test';
 
 describe('Protocol Helpers', function () {

--- a/test/unit/storage-client.spec.ts
+++ b/test/unit/storage-client.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client';
+import {ChromedriverStorageClient} from '../../lib/storage-client/storage-client.js';
 import {describe, it} from 'node:test';
 
 describe('ChromedriverStorageClient', function () {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {convertToInt} from '../../lib/utils';
+import {convertToInt} from '../../lib/utils.js';
 import {describe, it} from 'node:test';
 
 describe('utils', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "outDir": "build",
     "checkJs": true,
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": ["lib", "test"]
 }


### PR DESCRIPTION
## Summary

- Add "type": "module" and an exports map to package.json; keep main/types for compatibility.
- Explicitly set "module": "NodeNext" / "moduleResolution": "NodeNext" in tsconfig.json.
- Add .js extensions to all relative imports across lib/ and test/ (required by Node ESM resolution).
- Replace __filename usage with fileURLToPath(import.meta.url) in lib/utils.ts and test/unit/chromedriver.spec.ts.
- Replace the dynamic require() of config/mapping.json in lib/utils.ts with readFileSync + JSON.parse (the path is resolved at runtime via the module root, so a static JSON import isn't possible).
- Add esmock as a dev dependency and rework test/unit/chromedriver.spec.ts, which stubbed lib/utils.ts's getChromedriverBinaryPath/getChromeVersion via Sinon on a namespace import — real ES module namespaces are non-configurable and can't be mutated directly.
- Add --enable-source-maps to the test/e2e-test scripts.

BREAKING CHANGE: Consumers using require('appium-chromedriver') must switch to import/dynamic import() — the package no longer ships a CommonJS entry point.