### PR TITLE
feat!: drop legacy JSONWP protocol support, W3C only

### DIFF
--- a/lib/chromedriver.ts
+++ b/lib/chromedriver.ts
@@ -1,6 +1,6 @@
 import events from 'node:events';
 
-import {WebDriverProxy, PROTOCOLS} from '@appium/base-driver';
+import {WebDriverProxy} from '@appium/base-driver';
 import {logger, util} from '@appium/support';
 import type {ProxyOptions, HTTPMethod, HTTPBody} from '@appium/types';
 import type {ADB} from 'appium-adb';
@@ -15,15 +15,13 @@ import {
   initChromedriverPath,
 } from './commands/binary.js';
 import {buildChromedriverArgs, waitForOnline, getStatus, killAll} from './commands/process.js';
-import {syncProtocol, startSession, changeState, getCapValue, type SessionCapabilities} from './commands/session.js';
+import {startSession, changeState, getCapValue, type SessionCapabilities} from './commands/session.js';
 import {getChromeVersionForAutodetection} from './commands/version.js';
 import {CHROMEDRIVER_EVENTS, CHROMEDRIVER_STATES} from './constants.js';
 import {ChromedriverStorageClient} from './storage-client/storage-client.js';
 import type {ChromedriverOpts} from './types.js';
 import {getChromedriverDir, generateLogPrefix} from './utils.js';
 
-// Keep this import marked as used at runtime when it is otherwise only referenced in type positions.
-void PROTOCOLS;
 export type ChromedriverState = (typeof CHROMEDRIVER_STATES)[keyof typeof CHROMEDRIVER_STATES];
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -65,7 +63,6 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
   readonly storageClient: ChromedriverStorageClient | null;
   readonly details?: ChromedriverOpts['details'];
   capabilities: SessionCapabilities;
-  _desiredProtocol: keyof typeof PROTOCOLS | null;
   _driverVersion: string | null;
   _onlineStatus: Record<string, any> | null;
 
@@ -79,7 +76,6 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
   private getCompatibleChromedriver = getCompatibleChromedriver;
   private initChromedriverPath = initChromedriverPath;
   private getChromeVersion = getChromeVersionForAutodetection;
-  private syncProtocol = syncProtocol;
   private waitForOnline = waitForOnline;
   private getStatus = getStatus;
   private killAll = killAll;
@@ -139,7 +135,6 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
       : null;
     this.details = details;
     this.capabilities = {};
-    this._desiredProtocol = null;
     this._driverVersion = null;
     this._onlineStatus = null;
   }
@@ -170,7 +165,6 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
 
     try {
       await this.launchChromedriverProcess(args, webviewVersionHolder);
-      this.syncProtocol();
       return await this.startSession();
     } catch (e) {
       return await this.handleChromedriverStartFailure(e as Error, webviewVersionHolder.version);
@@ -232,7 +226,7 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
   }
 
   /**
-   * Sends a direct command to Chromedriver through the JSONWP/W3C proxy.
+   * Sends a direct command to Chromedriver through the W3C proxy.
    *
    * @param url - Chromedriver endpoint path.
    * @param method - HTTP method used for the command.
@@ -301,7 +295,6 @@ export class Chromedriver extends events.EventEmitter<ChromedriverEventMap> {
 
     proc.once('exit', (code: number | null, signal: string | null) => {
       this._driverVersion = null;
-      this._desiredProtocol = null;
       this._onlineStatus = null;
       if (
         this.state !== Chromedriver.STATE_STOPPED &&

--- a/lib/commands/session.ts
+++ b/lib/commands/session.ts
@@ -1,4 +1,4 @@
-import {PROTOCOLS, isStandardCap} from '@appium/base-driver';
+import {isStandardCap} from '@appium/base-driver';
 import {util} from '@appium/support';
 import * as semver from 'semver';
 
@@ -40,16 +40,12 @@ export function toW3cCapNames(originalCaps: Record<string, any> = {}): Record<st
 }
 
 /**
- * Creates a new Chromedriver session using the negotiated downstream protocol.
+ * Creates a new W3C Chromedriver session.
  */
 export async function startSession(this: ChromedriverCommandContext): Promise<SessionCapabilities> {
-  const sessionCaps =
-    this._desiredProtocol === PROTOCOLS.W3C
-      ? {capabilities: {alwaysMatch: toW3cCapNames(this.capabilities)}}
-      : {desiredCapabilities: this.capabilities};
-  this.log.info(
-    `Starting ${this._desiredProtocol} Chromedriver session with capabilities: ` + JSON.stringify(sessionCaps, null, 2),
-  );
+  applyW3cCapabilityQuirks.call(this);
+  const sessionCaps = {capabilities: {alwaysMatch: toW3cCapNames(this.capabilities)}};
+  this.log.info(`Starting W3C Chromedriver session with capabilities: ` + JSON.stringify(sessionCaps, null, 2));
   const response = (await this.jwproxy.command('/session', 'POST', sessionCaps)) as Record<string, any>;
   this.log.prefix = generateLogPrefix(this, this.jwproxy.sessionId);
   changeState.call(this, CHROMEDRIVER_STATES.ONLINE);
@@ -57,32 +53,28 @@ export async function startSession(this: ChromedriverCommandContext): Promise<Se
 }
 
 /**
- * Chooses W3C or MJSONWP protocol based on driver/capability constraints.
+ * Warns/adjusts capabilities for drivers with partial or opt-in W3C support.
+ * The legacy JSONWP protocol is no longer supported, so the W3C protocol is always requested.
  */
-export function syncProtocol(this: ChromedriverCommandContext): keyof typeof PROTOCOLS {
+function applyW3cCapabilityQuirks(this: ChromedriverCommandContext): void {
   if (this.driverVersion) {
     const coercedVersion = semver.coerce(this.driverVersion);
     if (!coercedVersion || coercedVersion.major < MIN_CD_VERSION_WITH_W3C_SUPPORT) {
-      this.log.info(
-        `The ChromeDriver v. ${this.driverVersion} does not fully support ${PROTOCOLS.W3C} protocol. ` +
-          `Defaulting to ${PROTOCOLS.MJSONWP}`,
+      this.log.warn(
+        `The ChromeDriver v. ${this.driverVersion} might not fully support the W3C WebDriver protocol. ` +
+          `Only versions ${MIN_CD_VERSION_WITH_W3C_SUPPORT}+ are guaranteed to work, since the legacy JSONWP protocol is no longer supported.`,
       );
-      this._desiredProtocol = PROTOCOLS.MJSONWP;
-      return this._desiredProtocol;
     }
+  }
+
+  const chromeOptions = getCapValue(this.capabilities, 'chromeOptions');
+  if (util.isPlainObject(chromeOptions) && chromeOptions.w3c === false) {
+    this.log.warn(`The 'chromeOptions.w3c: false' capability is no longer supported. Forcing the W3C protocol.`);
   }
 
   const statusMsg = this._onlineStatus?.message;
   const isOperaDriver = typeof statusMsg === 'string' && statusMsg.includes('OperaDriver');
-  const chromeOptions = getCapValue(this.capabilities, 'chromeOptions');
-  if (util.isPlainObject(chromeOptions) && chromeOptions.w3c === false) {
-    this.log.info(
-      `The ChromeDriver v. ${this.driverVersion} supports ${PROTOCOLS.W3C} protocol, ` +
-        `but ${PROTOCOLS.MJSONWP} one has been explicitly requested`,
-    );
-    this._desiredProtocol = PROTOCOLS.MJSONWP;
-    return this._desiredProtocol;
-  } else if (isOperaDriver) {
+  if (isOperaDriver) {
     // OperaDriver requires explicit W3C request or it falls back to JWP.
     if (util.isPlainObject(chromeOptions)) {
       chromeOptions.w3c = true;
@@ -90,9 +82,6 @@ export function syncProtocol(this: ChromedriverCommandContext): keyof typeof PRO
       this.capabilities[toW3cCapName('chromeOptions')] = {w3c: true};
     }
   }
-
-  this._desiredProtocol = PROTOCOLS.W3C;
-  return this._desiredProtocol;
 }
 
 /**

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1,8 +1,6 @@
 import type {EventEmitter} from 'node:events';
 
-// `keyof typeof PROTOCOLS` requires the runtime `PROTOCOLS` binding (not `import type`).
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- see above
-import {PROTOCOLS, type WebDriverProxy} from '@appium/base-driver';
+import type {WebDriverProxy} from '@appium/base-driver';
 import type {AppiumLogger} from '@appium/types';
 import type {ADB} from 'appium-adb';
 import type * as TeenProcess from 'teen_process';
@@ -29,7 +27,6 @@ export interface ChromedriverCommandContext extends EventEmitter {
   _execFunc: typeof TeenProcess.exec;
   _driverVersion: string | null;
   _onlineStatus: Record<string, any> | null;
-  _desiredProtocol: keyof typeof PROTOCOLS | null;
   capabilities: Record<string, any>;
   jwproxy: WebDriverProxy;
   log: AppiumLogger;


### PR DESCRIPTION
Chromedriver sessions are now always created with the W3C capabilities format. `chromeOptions.w3c: false` is no longer honored (a warning is logged instead), and the MJSONWP fallback for old Chromedriver versions has been removed in favor of a compatibility warning.

BREAKING CHANGE: clients relying on the legacy JSONWP protocol or the `chromeOptions.w3c: false` capability to force it will now get a W3C session instead.
BREAKING CHANGE: old chromedrivers that existed before W3C protocol has been implemented (v75 and older) aren't supported by this package anymore. 